### PR TITLE
Remove Analyze Debates and Grammar & Style buttons from Live Debates

### DIFF
--- a/PRONUNCIATION_INSIGHTS_SETUP.md
+++ b/PRONUNCIATION_INSIGHTS_SETUP.md
@@ -1,0 +1,216 @@
+# VocabPro Advanced Pronunciation Insights Setup
+
+## 🚀 Overview
+
+This comprehensive pronunciation insights system integrates:
+- **Whisper/OpenAI API** for accurate transcription and analysis
+- **Supabase** for storing pronunciation data and progress tracking
+- **Chart.js/Recharts** for glossy, interactive visualizations
+- **PDF Export** with html2canvas + jsPDF for detailed reports
+
+## 📋 Prerequisites
+
+1. **OpenAI API Key** - For Whisper transcription, TTS, and pronunciation analysis
+2. **ElevenLabs API Key** - For high-quality text-to-speech
+3. **Supabase Project** - For data storage and user management
+
+## 🔧 Setup Instructions
+
+### 1. Environment Variables
+
+Create/update your `.env` file with:
+
+```env
+# OpenAI Configuration
+VITE_OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+
+# ElevenLabs Configuration
+VITE_ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
+ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
+
+# Supabase Configuration
+VITE_SUPABASE_URL=your_supabase_project_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+```
+
+### 2. Supabase Database Setup
+
+Run the SQL schema in your Supabase SQL editor:
+
+```sql
+-- Copy and paste the contents of src/lib/supabase-schema.sql
+-- This creates tables for pronunciation_recordings, pronunciation_progress, and pronunciation_sessions
+```
+
+### 3. Install Dependencies
+
+The following packages have been added:
+
+```bash
+npm install recharts puppeteer html2canvas jspdf
+```
+
+### 4. Start the Proxy Servers
+
+The system requires two proxy servers for API calls:
+
+**Terminal 1 - ElevenLabs Proxy:**
+```bash
+npm run proxy:eleven
+```
+
+**Terminal 2 - OpenAI Proxy:**
+```bash
+npm run proxy:openai
+```
+
+**Terminal 3 - Main App:**
+```bash
+npm run dev
+```
+
+## 🎯 Features
+
+### Enhanced Pronunciation Analysis
+
+- **Whisper Transcription**: Accurate speech-to-text with confidence scores
+- **Phoneme Analysis**: Individual sound accuracy assessment
+- **Communication Style**: Clarity, fluency, and intonation scoring
+- **Speaking Rate**: Automatic detection of slow/normal/fast pace
+- **AI-Powered Suggestions**: Personalized improvement recommendations
+
+### Comprehensive Data Storage
+
+- **Recording History**: All pronunciation attempts stored in Supabase
+- **Progress Tracking**: Word-level improvement metrics over time
+- **Session Analytics**: Practice session summaries and insights
+- **User Profiles**: Individual progress and achievement tracking
+
+### Glossy Visualizations
+
+- **Pronunciation Scores**: Interactive bar charts with gradient styling
+- **Phoneme Accuracy**: Beautiful pie charts with hover effects
+- **Progress Tracking**: Smooth line charts showing improvement over time
+- **Communication Style**: Radar charts for multi-dimensional analysis
+- **KPI Cards**: Glossy metric cards with trend indicators
+
+### PDF Export System
+
+- **Comprehensive Reports**: Detailed pronunciation analysis reports
+- **Professional Styling**: Gradient backgrounds and modern typography
+- **Interactive Elements**: Clickable download and share buttons
+- **Multiple Export Options**: Download, share via Web Share API, email, WhatsApp
+
+## 🔧 API Endpoints
+
+### OpenAI Proxy (Port 8788)
+- `POST /api/openai/transcriptions` - Whisper transcription
+- `POST /api/openai/tts` - Text-to-speech generation
+- `POST /api/openai/chat` - Chat completions for analysis
+- `GET /health` - Health check
+
+### ElevenLabs Proxy (Port 3001)
+- `POST /elevenlabs/tts` - High-quality TTS
+- `POST /elevenlabs/s2s` - Speech-to-speech conversion
+- `GET /elevenlabs/health` - Health check
+
+## 📊 Data Flow
+
+1. **User Records Audio** → MediaRecorder captures audio blob
+2. **Audio Analysis** → Whisper transcribes + AI analyzes pronunciation
+3. **Data Storage** → Results stored in Supabase with user association
+4. **Visualization** → Charts display progress and insights
+5. **Report Generation** → PDF reports created on demand
+
+## 🎨 UI Components
+
+### Enhanced Charts (`src/components/EnhancedCharts.tsx`)
+- `GlossyPronunciationChart` - Bar chart for word scores
+- `GlossyPhonemeChart` - Pie chart for phoneme accuracy
+- `GlossyProgressChart` - Line chart for progress tracking
+- `GlossyCommunicationChart` - Radar chart for communication style
+- `GlossyKPICard` - Metric display cards
+
+### Pronunciation Analysis (`src/lib/pronunciationAnalysis.ts`)
+- `PronunciationAnalysisService` - Main analysis engine
+- Whisper integration for transcription
+- OpenAI chat completions for detailed analysis
+- Supabase integration for data persistence
+
+### PDF Export (`src/lib/pdfExport.ts`)
+- `PDFExportService` - Report generation engine
+- HTML template generation
+- Canvas-based PDF creation
+- Multiple sharing options
+
+## 🧪 Testing the System
+
+1. **Start all proxy servers** (see setup instructions above)
+2. **Navigate to Pronunciation Practice page**
+3. **Select or add a word** from the vocabulary section
+4. **Record pronunciation** - you'll see "AI analyzing..." indicator
+5. **Check Insights page** - view enhanced charts and metrics
+6. **Export PDF report** - test download and sharing features
+
+## 🔍 Troubleshooting
+
+### Common Issues
+
+1. **Analysis not working**: Check OpenAI API key and proxy server
+2. **Charts not displaying**: Ensure Chart.js dependencies are installed
+3. **PDF export failing**: Verify html2canvas and jsPDF are working
+4. **Data not persisting**: Check Supabase configuration and RLS policies
+
+### Debug Steps
+
+1. Check browser console for errors
+2. Verify proxy server logs
+3. Test API keys in Supabase and OpenAI dashboards
+4. Check network tab for failed requests
+
+## 🚀 Advanced Features
+
+### Custom Analysis Models
+- Extend `PronunciationAnalysisService` for domain-specific analysis
+- Add custom phoneme mappings for different languages
+- Implement specialized scoring algorithms
+
+### Enhanced Visualizations
+- Add more chart types using Recharts
+- Implement real-time waveform analysis
+- Create animated progress indicators
+
+### Export Options
+- Add PowerPoint export capability
+- Implement email integration
+- Create shareable web reports
+
+## 📈 Performance Optimization
+
+- **Audio Processing**: Optimize WAV conversion for faster analysis
+- **Chart Rendering**: Use React.memo for expensive chart components
+- **Data Caching**: Implement local storage for frequently accessed data
+- **API Rate Limiting**: Add request queuing for API calls
+
+## 🔐 Security Considerations
+
+- API keys are properly proxied through backend servers
+- Supabase RLS policies ensure user data isolation
+- Audio data is temporarily processed and can be automatically cleaned up
+- PDF generation happens client-side to protect user privacy
+
+---
+
+## 🎉 Ready to Use!
+
+Your VocabPro pronunciation insights system is now fully configured with:
+- ✅ Whisper-powered speech analysis
+- ✅ Supabase data persistence  
+- ✅ Glossy Chart.js visualizations
+- ✅ Professional PDF reports
+- ✅ Enhanced user experience
+
+Start recording and analyzing pronunciation to see the system in action!
+
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 VocabPro
+ 
+Environment Variables
+ 
+Add the following to your `.env` or `.env.local` (Vite uses `VITE_` prefix):
+ 
+```bash
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+VITE_OPENAI_API_KEY=sk-...
+# Optional: SerpAPI (web search)
+VITE_SERPAPI_KEY=your_serpapi_key
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,24 @@
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@supabase/supabase-js": "^2.39.0",
+        "@types/peerjs": "^0.0.30",
+        "audio-recorder-polyfill": "^0.4.1",
+        "chart.js": "^4.5.0",
+        "chrono-node": "^2.8.4",
+        "emoji-picker-react": "^4.9.7",
+        "express": "^4.19.2",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^3.0.1",
         "lucide-react": "^0.344.0",
+        "multer": "^1.4.5-lts.2",
+        "natural": "^6.7.1",
+        "peerjs": "^1.5.2",
+        "puppeteer": "^24.16.2",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.1"
+        "react-router-dom": "^6.30.1",
+        "recharts": "^3.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -61,7 +75,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
       "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.25.7",
         "picocolors": "^1.0.0"
@@ -206,7 +219,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
       "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -237,7 +249,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
       "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.7",
         "chalk": "^2.4.2",
@@ -291,6 +302,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1026,6 +1046,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
+      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1069,6 +1113,39 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
+      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.2",
+        "tar-fs": "^3.1.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@react-aria/focus": {
@@ -1166,6 +1243,97 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/router": {
@@ -1385,6 +1553,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.70.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
@@ -1496,6 +1676,12 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1537,6 +1723,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1558,6 +1807,15 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/peerjs": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/peerjs/-/peerjs-0.0.30.tgz",
+      "integrity": "sha512-yaWnpWhbf6qV3bJFRK3NLY3oX34J7/JMAXYahRNLSeDODCC/pHxF/9wSc3GtpA9DQF7dpeejDPkCdUp9knxVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webrtc": "*"
+      }
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
@@ -1568,13 +1826,20 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1589,11 +1854,55 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webrtc": {
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.46.tgz",
+      "integrity": "sha512-cvCnjKy0ma9ODWbVYBTMMB+WkocwLcscCwn2/caDVdb9MWaesS8PYGapIIHFsAaIBXRFlH1Fc7ZjIBO6pH0HKA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1847,6 +2156,19 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -1866,6 +2188,35 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/afinn-165": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
+      "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/afinn-165-financialmarketnews": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/afinn-165-financialmarketnews/-/afinn-165-financialmarketnews-3.0.0.tgz",
+      "integrity": "sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1900,7 +2251,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1927,6 +2277,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apparatus": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
+      "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
+      "license": "MIT",
+      "dependencies": {
+        "sylvester": ">= 0.0.8"
+      },
+      "engines": {
+        "node": ">=0.2.6"
+      }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -1936,8 +2304,43 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/audio-recorder-polyfill": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/audio-recorder-polyfill/-/audio-recorder-polyfill-0.4.1.tgz",
+      "integrity": "sha512-SS4qVOzuVwlS/tjQdd0uR+9cCKBTkx4jsAdjM+rMNqoTEWf6bMnBSTfv+FO4Zn9ngxviJOxhkgRWWXsAMqM96Q==",
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -1976,11 +2379,107 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.0.tgz",
+      "integrity": "sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1993,6 +2492,45 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2048,11 +2586,95 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2086,11 +2708,30 @@
         }
       ]
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2098,6 +2739,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -2136,6 +2789,136 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.3.1.tgz",
+      "integrity": "sha512-i+BMGluhZZc4Jic9L1aHJBTfaopxmCqQxGklyMcqFx4fvF3nI4BJ3bCe1ad474nvYRIo/ZN/VrdA4eOaRZua4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chrono-node": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.4.tgz",
+      "integrity": "sha512-F+Rq88qF3H2dwjnFrl3TZrn5v4ZO57XxeQ+AhuL1C685So1hdUV/hT/q8Ja5UbmPYEZfx8VrxFDa72Dgldcxpg==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.10.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2145,11 +2928,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -2157,8 +2948,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2175,11 +2965,106 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz",
+      "integrity": "sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2193,6 +3078,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2211,13 +3105,149 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2230,11 +3260,56 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1475386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
+      "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2248,11 +3323,53 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.33",
@@ -2260,11 +3377,102 @@
       "integrity": "sha512-+cYTcFB1QqD4j4LegwLfpCNxifb6dDFUAwk6RsLusCwIaZI6or2f+q8rs5tTB2YC53HhOlIbEaqHMAAC8IOIwA==",
       "dev": true
     },
+    "node_modules/emoji-picker-react": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.13.2.tgz",
+      "integrity": "sha512-azaJQLTshEOZVhksgU136izJWJyZ4Clx6xQ6Vctzk1gOdPPAUbTa/JYDwZJ8rh97QxnjpyeftXl99eRlYr3vNA==",
+      "license": "MIT",
+      "dependencies": {
+        "flairup": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.9",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.9.tgz",
+      "integrity": "sha512-9OtbkZmTA2Qc9groyA1PUNeb6knVTkvB2RSdr/LcJXDL8IdEakaxwXLHXa7VX/Wj0GmdMJPR3WhnPGhiP3E+qg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2308,18 +3516,43 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -2530,6 +3763,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -2558,7 +3804,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2567,9 +3812,104 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2577,6 +3917,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -2627,6 +3973,21 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2651,6 +4012,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2666,6 +4060,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flairup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -2702,6 +4102,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2713,6 +4122,15 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fsevents": {
@@ -2733,9 +4151,17 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -2745,6 +4171,81 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -2815,6 +4316,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2825,21 +4338,98 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -2851,11 +4441,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2875,6 +4474,45 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2916,7 +4554,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2941,6 +4578,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2996,7 +4639,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3022,6 +4664,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3044,6 +4692,33 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/keyv": {
@@ -3083,8 +4758,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3135,6 +4809,48 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memjs": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/memjs/-/memjs-1.3.2.tgz",
+      "integrity": "sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3142,6 +4858,15 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -3157,6 +4882,39 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3169,6 +4927,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -3178,11 +4945,180 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
+      "integrity": "sha512-fO5ttN9VC8P0F5fqtQmclAkgXZxbIkYRTUi1j8JO6IYwvamkhtYDilJr35jOPELR49zqCJgXZWwCtW7B+TM8vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.17.1.tgz",
+      "integrity": "sha512-aodS4cacux5caoxB5ErEwRmrafIUsVRJxHnvP7URnSUnTenr32j1qBVV+KjYxryyLSisQkxglAFF69TNLeZTLg==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.18.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
+      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -3213,11 +5149,54 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/natural/-/natural-6.12.0.tgz",
+      "integrity": "sha512-ZV/cuaxOvJ7CSxQRYHc6nlx7ql6hVPQc20N5ubdqVbotWnnqsNc+0/QG+ACIC3XPQ4rfrQrdC/1k47v1cSszTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "afinn-165": "^1.0.2",
+        "afinn-165-financialmarketnews": "^3.0.0",
+        "apparatus": "^0.0.10",
+        "dotenv": "^16.4.5",
+        "memjs": "^1.3.2",
+        "mongoose": "^8.2.0",
+        "pg": "^8.11.3",
+        "redis": "^4.6.13",
+        "safe-stable-stringify": "^2.2.0",
+        "stopwords-iso": "^1.1.0",
+        "sylvester": "^0.0.12",
+        "underscore": "^1.9.1",
+        "uuid": "^9.0.1",
+        "wordnet-db": "^3.1.11"
+      },
+      "engines": {
+        "node": ">=0.4.10"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -3247,7 +5226,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3259,6 +5237,39 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -3308,6 +5319,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3318,12 +5361,38 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/path-exists": {
@@ -3372,11 +5441,150 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/peerjs": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
+      "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^2.8.0",
+        "eventemitter3": "^4.0.7",
+        "peerjs-js-binarypack": "^2.1.0",
+        "webrtc-adapter": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs-js-binarypack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
+      "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3551,6 +5759,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3560,13 +5807,137 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.16.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.16.2.tgz",
+      "integrity": "sha512-eNjKzwjITM4Lvho6iHb+VQamadUBgc8TsjAApsKi5N8DXipxAaAZWssBOFsrIOLo4eYWYj0Qk5gmr4wBSqzJWw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.6",
+        "chromium-bidi": "7.3.1",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1475386",
+        "puppeteer-core": "24.16.2",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.16.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.16.2.tgz",
+      "integrity": "sha512-areKSSQzpoHa5nCk3uD/o504yjrW5ws0N6jZfdFZ3a4H+Q7NBgvuDydjN5P87jN4Rj+eIpLcK3ELOThTtYuuxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.6",
+        "chromium-bidi": "7.3.1",
+        "debug": "^4.4.1",
+        "devtools-protocol": "0.0.1475386",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -3589,6 +5960,40 @@
         }
       ]
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3598,6 +6003,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -3610,6 +6025,36 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -3662,6 +6107,27 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3673,6 +6139,93 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.2.tgz",
+      "integrity": "sha512-vhNbYwaxNbk/IATK0Ki29k3qvTkGqwvCgyQAQ9MavvvBwjvKnMTswdbklJpcOAoMPN/qxF3Lyqob0zO+ZXkZ4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -3695,7 +6248,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -3708,6 +6260,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -3768,6 +6330,41 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3775,6 +6372,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -3784,6 +6387,75 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3806,6 +6478,84 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3818,6 +6568,54 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3826,6 +6624,88 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stopwords-iso": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stopwords-iso/-/stopwords-iso-1.1.0.tgz",
+      "integrity": "sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -3961,7 +6841,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -3979,6 +6858,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/sylvester": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.12.tgz",
+      "integrity": "sha512-SzRP5LQ6Ts2G5NyAa/jg16s8e3R7rfdFjizy1zeoecYWw+nGL+YA1xZvW/+iJmidBGSdLkuvdwTYEyJEb+EiUw==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/tabbable": {
@@ -4024,6 +6921,49 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4051,6 +6991,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -4070,6 +7016,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {
@@ -4114,11 +7069,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4150,11 +7130,26 @@
         }
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
@@ -4207,8 +7202,69 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.8",
@@ -4275,6 +7331,19 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
+      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -4307,6 +7376,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordnet-db": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
+      "integrity": "sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -4430,6 +7508,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -4451,6 +7535,24 @@
         }
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -4469,6 +7571,84 @@
         "node": ">= 14"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4479,6 +7659,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,15 +7,31 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "proxy:eleven": "node server/elevanlabs-proxy.js",
+    "proxy:openai": "node server/openai-proxy.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
     "@supabase/supabase-js": "^2.39.0",
+    "@types/peerjs": "^0.0.30",
+    "audio-recorder-polyfill": "^0.4.1",
+    "chart.js": "^4.5.0",
+    "chrono-node": "^2.8.4",
+    "emoji-picker-react": "^4.9.7",
+    "express": "^4.19.2",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^3.0.1",
     "lucide-react": "^0.344.0",
+    "multer": "^1.4.5-lts.2",
+    "natural": "^6.7.1",
+    "peerjs": "^1.5.2",
+    "puppeteer": "^24.16.2",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "recharts": "^3.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/elevanlabs-proxy.js
+++ b/server/elevanlabs-proxy.js
@@ -1,0 +1,96 @@
+// Simple ElevenLabs proxy (dev-use). Do NOT expose without auth in production.
+import 'dotenv/config';
+import express from 'express';
+import multer from 'multer';
+
+// Node 18+ has global fetch; no import needed
+
+const app = express();
+app.use(express.json({ limit: '10mb' }));
+
+// Minimal CORS so the Vite dev server can call this proxy
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, xi-api-key');
+  if (req.method === 'OPTIONS') return res.sendStatus(204);
+  next();
+});
+
+const upload = multer();
+
+const API_KEY = process.env.ELEVENLABS_API_KEY || process.env.VITE_ELEVENLABS_API_KEY;
+const BASE = 'https://api.elevenlabs.io/v1';
+
+app.post('/elevenlabs/tts', async (req, res) => {
+  try {
+    const { text, voiceId = '21m00Tcm4TlvDq8ikWAM', model_id = 'eleven_turbo_v2' } = req.body || {};
+    if (!text || typeof text !== 'string' || text.trim().length === 0) {
+      return res.status(400).json({ error: 'missing_text' });
+    }
+    const r = await fetch(`${BASE}/text-to-speech/${voiceId}`, {
+      method: 'POST',
+      headers: { accept: 'audio/mpeg', 'content-type': 'application/json', 'xi-api-key': API_KEY },
+      body: JSON.stringify({ text, model_id })
+    });
+    if (!r.ok) {
+      const body = await r.text();
+      return res.status(r.status).send(body || 'tts_error');
+    }
+    res.setHeader('content-type', 'audio/mpeg');
+    r.body.pipe(res);
+  } catch (e) {
+    res.status(500).json({ error: 'proxy_error', message: e?.message || 'unknown' });
+  }
+});
+
+// Health check – verifies proxy is up and API key is valid
+app.get('/elevenlabs/health', async (req, res) => {
+  try {
+    const r = await fetch(`${BASE}/user`, {
+      headers: { 'xi-api-key': API_KEY }
+    });
+    if (!r.ok) {
+      const msg = await r.text();
+      return res.status(200).json({ ok: false, status: r.status, message: msg || 'invalid_key_or_plan' });
+    }
+    const info = await r.json().catch(() => ({}));
+    res.json({ ok: true, info });
+  } catch (e) {
+    res.status(200).json({ ok: false, message: 'proxy_offline_or_network' });
+  }
+});
+
+app.post('/elevenlabs/s2s', upload.single('file'), async (req, res) => {
+  try {
+    const voiceId = req.body.voiceId || '21m00Tcm4TlvDq8ikWAM';
+    const endpoint = `${BASE}/speech-to-speech/${voiceId}?output_format=mp3_44100_128&model_id=eleven_english_sts_v2`;
+    if (!req.file || !req.file.buffer) {
+      return res.status(400).json({ error: 'missing_audio' });
+    }
+    // Send multipart/form-data with field name 'audio'
+    const form = new FormData();
+    const blob = new Blob([req.file.buffer], { type: req.file.mimetype || 'audio/wav' });
+    form.append('audio', blob, 'input.wav');
+    const r = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'xi-api-key': API_KEY, 'accept': 'audio/mpeg' },
+      body: form
+    });
+    if (!r.ok) {
+      const errText = await r.text();
+      return res.status(r.status).send(errText);
+    }
+    res.setHeader('content-type', 'audio/mpeg');
+    r.body.pipe(res);
+  } catch (e) { res.status(500).json({ error: 'proxy_error' }); }
+});
+
+const port = process.env.PORT || 8787;
+app.listen(port, () => console.log(`ElevenLabs proxy listening on :${port}`));
+
+
+
+
+
+

--- a/server/openai-proxy.js
+++ b/server/openai-proxy.js
@@ -1,0 +1,165 @@
+// Enhanced OpenAI proxy for Whisper, TTS, and Chat completions
+import express from 'express';
+import multer from 'multer';
+import FormData from 'form-data';
+
+const app = express();
+
+// CORS middleware
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+  if (req.method === 'OPTIONS') {
+    res.sendStatus(200);
+  } else {
+    next();
+  }
+});
+
+app.use(express.json({ limit: '10mb' }));
+const upload = multer();
+
+const API_KEY = process.env.OPENAI_API_KEY || process.env.VITE_OPENAI_API_KEY;
+const BASE = 'https://api.openai.com/v1';
+
+console.log('OpenAI API Key available:', !!API_KEY);
+
+// Health check
+app.get('/health', (_req, res) => res.json({ 
+  ok: true, 
+  timestamp: new Date().toISOString(),
+  endpoints: ['/api/openai/transcriptions', '/api/openai/tts', '/api/openai/chat']
+}));
+
+// Whisper transcription proxy with enhanced response
+app.post('/api/openai/transcriptions', upload.any(), async (req, res) => {
+  try {
+    const auth = req.headers['authorization'] || (API_KEY ? `Bearer ${API_KEY}` : undefined);
+    if (!auth) return res.status(401).json({ error: 'missing_api_key' });
+
+    // Rebuild FormData request
+    const form = new FormData();
+    const filePart = (req.files && req.files.find(f => f.fieldname === 'file')) || req.files?.[0];
+    if (filePart) {
+      form.append('file', filePart.buffer, filePart.originalname || 'audio.wav');
+    }
+    
+    // Add other form fields
+    for (const [k, v] of Object.entries(req.body || {})) {
+      form.append(k, v);
+    }
+
+    const response = await fetch(`${BASE}/audio/transcriptions`, {
+      method: 'POST',
+      headers: { 
+        Authorization: auth,
+        ...form.getHeaders()
+      },
+      body: form
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('OpenAI Transcription error:', errorText);
+      return res.status(response.status).json({ error: 'transcription_failed', details: errorText });
+    }
+
+    const result = await response.json();
+    res.json(result);
+  } catch (error) {
+    console.error('Transcription proxy error:', error);
+    res.status(500).json({ error: 'proxy_error', details: error.message });
+  }
+});
+
+// OpenAI TTS proxy
+app.post('/api/openai/tts', async (req, res) => {
+  try {
+    const auth = req.headers['authorization'] || (API_KEY ? `Bearer ${API_KEY}` : undefined);
+    if (!auth) return res.status(401).json({ error: 'missing_api_key' });
+    
+    const { text, voice = 'alloy', model = 'tts-1', speed = 1.0 } = req.body || {};
+    if (!text) return res.status(400).json({ error: 'missing_text' });
+
+    const response = await fetch(`${BASE}/audio/speech`, {
+      method: 'POST',
+      headers: { 
+        Authorization: auth, 
+        'Content-Type': 'application/json' 
+      },
+      body: JSON.stringify({ 
+        model, 
+        voice, 
+        input: text, 
+        response_format: 'mp3',
+        speed 
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('OpenAI TTS error:', errorText);
+      return res.status(response.status).json({ error: 'tts_failed', details: errorText });
+    }
+
+    res.setHeader('Content-Type', 'audio/mpeg');
+    response.body.pipe(res);
+  } catch (error) {
+    console.error('TTS proxy error:', error);
+    res.status(500).json({ error: 'proxy_error', details: error.message });
+  }
+});
+
+// OpenAI Chat completions proxy for pronunciation analysis
+app.post('/api/openai/chat', async (req, res) => {
+  try {
+    const auth = req.headers['authorization'] || (API_KEY ? `Bearer ${API_KEY}` : undefined);
+    if (!auth) return res.status(401).json({ error: 'missing_api_key' });
+
+    const { messages, model = 'gpt-4o-mini', temperature = 0.7, max_tokens = 1000 } = req.body || {};
+    if (!messages || !Array.isArray(messages)) {
+      return res.status(400).json({ error: 'messages_required' });
+    }
+
+    const response = await fetch(`${BASE}/chat/completions`, {
+      method: 'POST',
+      headers: { 
+        Authorization: auth, 
+        'Content-Type': 'application/json' 
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        temperature,
+        max_tokens
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('OpenAI Chat error:', errorText);
+      return res.status(response.status).json({ error: 'chat_failed', details: errorText });
+    }
+
+    const result = await response.json();
+    res.json(result);
+  } catch (error) {
+    console.error('Chat proxy error:', error);
+    res.status(500).json({ error: 'proxy_error', details: error.message });
+  }
+});
+
+const port = process.env.PORT || 8788;
+app.listen(port, () => {
+  console.log(`Enhanced OpenAI proxy listening on :${port}`);
+  console.log('Available endpoints:');
+  console.log('  POST /api/openai/transcriptions - Whisper transcription');
+  console.log('  POST /api/openai/tts - Text-to-speech');
+  console.log('  POST /api/openai/chat - Chat completions');
+  console.log('  GET /health - Health check');
+});
+
+
+
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,12 @@ import PronunciationPractice from './components/PronunciationPractice';
 import JamSessions from './components/JamSessions';
 import Debates from './components/Debates';
 import DebateTournament from './components/DebateTournament';
+import { IntegrationTest } from './components/IntegrationTest';
+import { SignupDebug } from './components/SignupDebug';
+import { NetworkTest } from './components/NetworkTest';
+import MediaRecorderTest from './components/MediaRecorderTest';
+import PeerTest from './components/PeerTest';
+import ChartsDemo from './components/ChartsDemo';
 
 export interface LibraryItem {
   name: string;
@@ -181,6 +187,12 @@ function App() {
               <Route path="/dictation-quiz" element={<DictationQuiz />} />
               <Route path="/debates" element={user ? <Debates /> : <Navigate to="/login" />} />
               <Route path="/debate-tournament" element={user ? <DebateTournament /> : <Navigate to="/login" />} />
+              <Route path="/test-integrations" element={<IntegrationTest />} />
+              <Route path="/signup-debug" element={<SignupDebug />} />
+              <Route path="/network-test" element={<NetworkTest />} />
+              <Route path="/mediarecorder-test" element={<MediaRecorderTest />} />
+              <Route path="/peer-test" element={<PeerTest />} />
+              <Route path="/charts-demo" element={<ChartsDemo />} />
               <Route path="/*" element={<LandingPage />} />
             </Routes>
           </BrowserRouter>

--- a/src/components/ChartsDemo.tsx
+++ b/src/components/ChartsDemo.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+	Chart as ChartJS,
+	CategoryScale,
+	LinearScale,
+	PointElement,
+	LineElement,
+	BarElement,
+	Title,
+	Tooltip,
+	Legend,
+} from 'chart.js';
+import { Line, Bar } from 'react-chartjs-2';
+
+ChartJS.register(
+	CategoryScale,
+	LinearScale,
+	PointElement,
+	LineElement,
+	BarElement,
+	Title,
+	Tooltip,
+	Legend
+);
+
+export default function ChartsDemo() {
+	const lineData = {
+		labels: ['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Week 5'],
+		datasets: [
+			{
+				label: 'Words Learned',
+				data: [12, 18, 25, 34, 47],
+				borderColor: 'rgb(99, 102, 241)',
+				backgroundColor: 'rgba(99, 102, 241, 0.2)',
+				tension: 0.3,
+				fill: true,
+			},
+		],
+	};
+
+	const barData = {
+		labels: ['Pronunciation', 'Pace', 'Confidence', 'Clarity'],
+		datasets: [
+			{
+				label: 'Scores',
+				data: [82, 74, 88, 91],
+				backgroundColor: ['#60a5fa', '#34d399', '#f59e0b', '#a78bfa'],
+			},
+		],
+	};
+
+	const commonOptions = {
+		responsive: true,
+		plugins: {
+			legend: { position: 'top' as const },
+			title: { display: true, text: 'Learning Insights' },
+		},
+	};
+
+	return (
+		<div className="max-w-4xl mx-auto p-6 space-y-8">
+			<h2 className="text-2xl font-bold">Charts Demo</h2>
+			<div className="bg-white/10 backdrop-blur rounded-xl border border-white/20 p-4">
+				<Line options={commonOptions} data={lineData} />
+			</div>
+			<div className="bg-white/10 backdrop-blur rounded-xl border border-white/20 p-4">
+				<Bar options={commonOptions} data={barData} />
+			</div>
+		</div>
+	);
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Brain, LogOut, User, Settings, BookOpen, Mic, BarChart3, Trophy, Sparkles, File, FileText, Music, Image as ImageIcon, Link as LinkIcon } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
@@ -12,6 +12,31 @@ interface DashboardProps {
 function Dashboard({ onLogout, libraryItems }: DashboardProps) {
   const { user, signOut } = useAuth();
   const navigate = useNavigate();
+  type RecentWord = { id: number; word: string; createdAt: string };
+  type RecentRecording = { id: number; word: string; url: string; createdAt: string };
+  const [recentWords, setRecentWords] = useState<RecentWord[]>([]);
+  const [recentRecordings, setRecentRecordings] = useState<RecentRecording[]>([]);
+
+  useEffect(() => {
+    try {
+      const w = JSON.parse(localStorage.getItem('recentWords') || '[]');
+      if (Array.isArray(w)) setRecentWords(w);
+    } catch {}
+    try {
+      const r = JSON.parse(localStorage.getItem('recentRecordings') || '[]');
+      if (Array.isArray(r)) setRecentRecordings(r);
+    } catch {}
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'recentWords') {
+        try { const w = JSON.parse(e.newValue || '[]'); if (Array.isArray(w)) setRecentWords(w); } catch {}
+      }
+      if (e.key === 'recentRecordings') {
+        try { const r = JSON.parse(e.newValue || '[]'); if (Array.isArray(r)) setRecentRecordings(r); } catch {}
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
 
   const groupByType = (items: LibraryItem[]) => {
     return {
@@ -178,6 +203,48 @@ function Dashboard({ onLogout, libraryItems }: DashboardProps) {
                 </div>
               </div>
             ))}
+          </div>
+        </section>
+
+        {/* Practice Activity (Synced) */}
+        <section className="w-full max-w-6xl bg-white/90 rounded-2xl shadow-lg p-8 mb-8">
+          <h2 className="text-2xl font-bold text-purple-900 mb-6">Practice Activity</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+            {/* Words list */}
+            <div>
+              <h3 className="text-lg font-semibold text-blue-700 mb-3">Words</h3>
+              <ul className="flex flex-col gap-3">
+                {recentWords.length > 0 ? (
+                  recentWords.slice(0, 10).map((w) => (
+                    <li key={w.id} className="flex items-center justify-between bg-white rounded-lg shadow p-3">
+                      <span className="font-semibold text-gray-800">{w.word}</span>
+                      <span className="text-xs text-gray-500">{new Date(w.createdAt).toLocaleString()}</span>
+                    </li>
+                  ))
+                ) : (
+                  <li className="text-gray-400 text-sm">No recent words.</li>
+                )}
+              </ul>
+            </div>
+            {/* Recordings list */}
+            <div>
+              <h3 className="text-lg font-semibold text-blue-700 mb-3">Recordings</h3>
+              <ul className="flex flex-col gap-3">
+                {recentRecordings.length > 0 ? (
+                  recentRecordings.slice(0, 10).map((r) => (
+                    <li key={r.id} className="bg-white rounded-lg shadow p-3">
+                      <div className="flex items-center justify-between mb-2">
+                        <span className="font-semibold text-gray-800">{r.word || 'Recording'}</span>
+                        <span className="text-xs text-gray-500">{new Date(r.createdAt).toLocaleString()}</span>
+                      </div>
+                      <audio controls src={r.url} className="w-full" />
+                    </li>
+                  ))
+                ) : (
+                  <li className="text-gray-400 text-sm">No recent recordings.</li>
+                )}
+              </ul>
+            </div>
           </div>
         </section>
       </main>

--- a/src/components/EnhancedCharts.tsx
+++ b/src/components/EnhancedCharts.tsx
@@ -1,0 +1,513 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  ArcElement,
+  LineElement,
+  PointElement,
+  RadialLinearScale,
+} from 'chart.js';
+import { Bar, Pie, Line, Radar } from 'react-chartjs-2';
+import {
+  BarChart,
+  Bar as RechartsBar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  Legend as RechartsLegend,
+  ResponsiveContainer,
+  PieChart,
+  Pie as RechartsPie,
+  Cell,
+  LineChart,
+  Line as RechartsLine,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar as RechartsRadar,
+  Area,
+  AreaChart,
+} from 'recharts';
+
+// Register Chart.js components
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+  ArcElement,
+  LineElement,
+  PointElement,
+  RadialLinearScale
+);
+
+// Glossy color palettes
+const glossyColors = {
+  primary: ['#667eea', '#764ba2', '#f093fb', '#f5576c', '#4facfe', '#00f2fe'],
+  secondary: ['#a8edea', '#fed6e3', '#d299c2', '#fef9d7', '#667eea', '#764ba2'],
+  gradient: [
+    'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+    'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+    'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
+    'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
+    'linear-gradient(135deg, #fa709a 0%, #fee140 100%)',
+    'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)',
+  ]
+};
+
+interface PronunciationScoreData {
+  word: string;
+  score: number;
+  attempts: number;
+  difficulty: 'easy' | 'medium' | 'hard';
+}
+
+interface PhonemeAccuracyData {
+  phoneme: string;
+  accuracy: number;
+}
+
+interface ProgressData {
+  date: string;
+  score: number;
+  wordsPerMinute: number;
+}
+
+interface CommunicationStyleData {
+  category: string;
+  score: number;
+  fullMark: number;
+}
+
+// Glossy Bar Chart for Pronunciation Scores
+export const GlossyPronunciationChart: React.FC<{ data: PronunciationScoreData[] }> = ({ data }) => {
+  const chartData = {
+    labels: data.map(d => d.word),
+    datasets: [
+      {
+        label: 'Pronunciation Score',
+        data: data.map(d => d.score * 100),
+        backgroundColor: data.map((_, index) => glossyColors.primary[index % glossyColors.primary.length]),
+        borderColor: data.map((_, index) => glossyColors.primary[index % glossyColors.primary.length]),
+        borderWidth: 2,
+        borderRadius: 8,
+        borderSkipped: false,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+        labels: {
+          color: '#e2e8f0',
+          font: {
+            size: 14,
+            weight: 'bold',
+          },
+        },
+      },
+      title: {
+        display: true,
+        text: 'Pronunciation Accuracy by Word',
+        color: '#f1f5f9',
+        font: {
+          size: 18,
+          weight: 'bold',
+        },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: '#ffffff',
+        bodyColor: '#e2e8f0',
+        borderColor: '#667eea',
+        borderWidth: 1,
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        max: 100,
+        ticks: {
+          color: '#cbd5e1',
+          font: {
+            size: 12,
+          },
+        },
+        grid: {
+          color: 'rgba(203, 213, 225, 0.1)',
+        },
+      },
+      x: {
+        ticks: {
+          color: '#cbd5e1',
+          font: {
+            size: 12,
+          },
+        },
+        grid: {
+          color: 'rgba(203, 213, 225, 0.1)',
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-sm rounded-2xl p-6 border border-slate-600/30">
+      <Bar data={chartData} options={options} />
+    </div>
+  );
+};
+
+// Glossy Pie Chart for Phoneme Accuracy
+export const GlossyPhonemeChart: React.FC<{ data: PhonemeAccuracyData[] }> = ({ data }) => {
+  const chartData = {
+    labels: data.map(d => d.phoneme),
+    datasets: [
+      {
+        data: data.map(d => d.accuracy * 100),
+        backgroundColor: glossyColors.primary,
+        borderColor: glossyColors.secondary,
+        borderWidth: 3,
+        hoverBorderWidth: 4,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: 'right' as const,
+        labels: {
+          color: '#e2e8f0',
+          font: {
+            size: 12,
+            weight: 'bold',
+          },
+          padding: 20,
+        },
+      },
+      title: {
+        display: true,
+        text: 'Phoneme Accuracy Breakdown',
+        color: '#f1f5f9',
+        font: {
+          size: 18,
+          weight: 'bold',
+        },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: '#ffffff',
+        bodyColor: '#e2e8f0',
+        borderColor: '#667eea',
+        borderWidth: 1,
+        callbacks: {
+          label: function(context: any) {
+            return `${context.label}: ${context.parsed.toFixed(1)}%`;
+          }
+        }
+      },
+    },
+  };
+
+  return (
+    <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-sm rounded-2xl p-6 border border-slate-600/30">
+      <Pie data={chartData} options={options} />
+    </div>
+  );
+};
+
+// Glossy Progress Line Chart
+export const GlossyProgressChart: React.FC<{ data: ProgressData[] }> = ({ data }) => {
+  const chartData = {
+    labels: data.map(d => new Date(d.date).toLocaleDateString()),
+    datasets: [
+      {
+        label: 'Pronunciation Score',
+        data: data.map(d => d.score * 100),
+        borderColor: '#667eea',
+        backgroundColor: 'rgba(102, 126, 234, 0.1)',
+        borderWidth: 3,
+        fill: true,
+        tension: 0.4,
+        pointBackgroundColor: '#667eea',
+        pointBorderColor: '#ffffff',
+        pointBorderWidth: 2,
+        pointRadius: 6,
+        pointHoverRadius: 8,
+      },
+      {
+        label: 'Words Per Minute',
+        data: data.map(d => d.wordsPerMinute),
+        borderColor: '#f093fb',
+        backgroundColor: 'rgba(240, 147, 251, 0.1)',
+        borderWidth: 3,
+        fill: true,
+        tension: 0.4,
+        pointBackgroundColor: '#f093fb',
+        pointBorderColor: '#ffffff',
+        pointBorderWidth: 2,
+        pointRadius: 6,
+        pointHoverRadius: 8,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+        labels: {
+          color: '#e2e8f0',
+          font: {
+            size: 14,
+            weight: 'bold',
+          },
+        },
+      },
+      title: {
+        display: true,
+        text: 'Progress Over Time',
+        color: '#f1f5f9',
+        font: {
+          size: 18,
+          weight: 'bold',
+        },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: '#ffffff',
+        bodyColor: '#e2e8f0',
+        borderColor: '#667eea',
+        borderWidth: 1,
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          color: '#cbd5e1',
+          font: {
+            size: 12,
+          },
+        },
+        grid: {
+          color: 'rgba(203, 213, 225, 0.1)',
+        },
+      },
+      x: {
+        ticks: {
+          color: '#cbd5e1',
+          font: {
+            size: 12,
+          },
+        },
+        grid: {
+          color: 'rgba(203, 213, 225, 0.1)',
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-sm rounded-2xl p-6 border border-slate-600/30">
+      <Line data={chartData} options={options} />
+    </div>
+  );
+};
+
+// Glossy Radar Chart for Communication Style
+export const GlossyCommunicationChart: React.FC<{ data: CommunicationStyleData[] }> = ({ data }) => {
+  const chartData = {
+    labels: data.map(d => d.category),
+    datasets: [
+      {
+        label: 'Communication Score',
+        data: data.map(d => d.score * 100),
+        backgroundColor: 'rgba(102, 126, 234, 0.2)',
+        borderColor: '#667eea',
+        borderWidth: 3,
+        pointBackgroundColor: '#667eea',
+        pointBorderColor: '#ffffff',
+        pointBorderWidth: 2,
+        pointRadius: 6,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+        labels: {
+          color: '#e2e8f0',
+          font: {
+            size: 14,
+            weight: 'bold',
+          },
+        },
+      },
+      title: {
+        display: true,
+        text: 'Communication Style Analysis',
+        color: '#f1f5f9',
+        font: {
+          size: 18,
+          weight: 'bold',
+        },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: '#ffffff',
+        bodyColor: '#e2e8f0',
+        borderColor: '#667eea',
+        borderWidth: 1,
+      },
+    },
+    scales: {
+      r: {
+        angleLines: {
+          color: 'rgba(203, 213, 225, 0.3)',
+        },
+        grid: {
+          color: 'rgba(203, 213, 225, 0.3)',
+        },
+        pointLabels: {
+          color: '#e2e8f0',
+          font: {
+            size: 12,
+          },
+        },
+        ticks: {
+          color: '#cbd5e1',
+          backdropColor: 'transparent',
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-sm rounded-2xl p-6 border border-slate-600/30">
+      <Radar data={chartData} options={options} />
+    </div>
+  );
+};
+
+// Recharts Alternative - Glossy Bar Chart
+export const RechartsGlossyBar: React.FC<{ data: any[] }> = ({ data }) => {
+  return (
+    <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-sm rounded-2xl p-6 border border-slate-600/30">
+      <h3 className="text-xl font-bold text-slate-100 mb-4">Word Difficulty Distribution</h3>
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(203, 213, 225, 0.1)" />
+          <XAxis dataKey="difficulty" tick={{ fill: '#cbd5e1', fontSize: 12 }} />
+          <YAxis tick={{ fill: '#cbd5e1', fontSize: 12 }} />
+          <RechartsTooltip 
+            contentStyle={{
+              backgroundColor: 'rgba(0, 0, 0, 0.8)',
+              border: '1px solid #667eea',
+              borderRadius: '8px',
+              color: '#e2e8f0'
+            }}
+          />
+          <RechartsLegend wrapperStyle={{ color: '#e2e8f0' }} />
+          <RechartsBar dataKey="count" fill="url(#colorGradient)" radius={[4, 4, 0, 0]} />
+          <defs>
+            <linearGradient id="colorGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#667eea" stopOpacity={0.8}/>
+              <stop offset="95%" stopColor="#764ba2" stopOpacity={0.8}/>
+            </linearGradient>
+          </defs>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+// Recharts Glossy Area Chart for Progress
+export const RechartsGlossyArea: React.FC<{ data: any[] }> = ({ data }) => {
+  return (
+    <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-sm rounded-2xl p-6 border border-slate-600/30">
+      <h3 className="text-xl font-bold text-slate-100 mb-4">Learning Progress</h3>
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(203, 213, 225, 0.1)" />
+          <XAxis dataKey="date" tick={{ fill: '#cbd5e1', fontSize: 12 }} />
+          <YAxis tick={{ fill: '#cbd5e1', fontSize: 12 }} />
+          <RechartsTooltip 
+            contentStyle={{
+              backgroundColor: 'rgba(0, 0, 0, 0.8)',
+              border: '1px solid #667eea',
+              borderRadius: '8px',
+              color: '#e2e8f0'
+            }}
+          />
+          <Area 
+            type="monotone" 
+            dataKey="score" 
+            stroke="#667eea" 
+            fill="url(#areaGradient)" 
+            strokeWidth={3}
+          />
+          <defs>
+            <linearGradient id="areaGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#667eea" stopOpacity={0.3}/>
+              <stop offset="95%" stopColor="#667eea" stopOpacity={0.05}/>
+            </linearGradient>
+          </defs>
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+// KPI Cards with Glossy Design
+export const GlossyKPICard: React.FC<{
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon?: React.ReactNode;
+  gradient?: string;
+  trend?: 'up' | 'down' | 'stable';
+}> = ({ title, value, subtitle, icon, gradient = 'from-blue-500 to-purple-600', trend }) => {
+  const trendIcon = trend === 'up' ? '↗️' : trend === 'down' ? '↘️' : '→';
+  const trendColor = trend === 'up' ? 'text-green-400' : trend === 'down' ? 'text-red-400' : 'text-yellow-400';
+
+  return (
+    <div className={`bg-gradient-to-br ${gradient} p-6 rounded-2xl shadow-2xl border border-white/20 backdrop-blur-sm transform hover:scale-105 transition-all duration-300`}>
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-white/80 text-sm font-medium uppercase tracking-wide">
+          {title}
+        </div>
+        {icon && <div className="text-white/60">{icon}</div>}
+      </div>
+      <div className="text-3xl font-bold text-white mb-2">
+        {value}
+      </div>
+      {subtitle && (
+        <div className="flex items-center gap-2">
+          <span className="text-white/70 text-sm">{subtitle}</span>
+          {trend && <span className={`${trendColor} text-sm`}>{trendIcon}</span>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+

--- a/src/components/IntegrationTest.tsx
+++ b/src/components/IntegrationTest.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { runIntegrationTests } from '../test-integrations';
+
+export function IntegrationTest() {
+  const [testResults, setTestResults] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  const runTests = async () => {
+    setLoading(true);
+    try {
+      const results = await runIntegrationTests();
+      setTestResults(results);
+    } catch (error) {
+      setTestResults({ error: error instanceof Error ? error.message : 'Unknown error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">MCP Integration Tests</h2>
+      
+      <button
+        onClick={runTests}
+        disabled={loading}
+        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 disabled:opacity-50"
+      >
+        {loading ? 'Running Tests...' : 'Run Integration Tests'}
+      </button>
+
+      {testResults && (
+        <div className="space-y-4">
+          <div className="border rounded p-4">
+            <h3 className="font-semibold mb-2">GitHub MCP Integration</h3>
+            <div className={`p-2 rounded ${testResults.github?.success ? 'bg-green-100' : 'bg-red-100'}`}>
+              <pre className="text-sm">{JSON.stringify(testResults.github, null, 2)}</pre>
+            </div>
+          </div>
+
+          <div className="border rounded p-4">
+            <h3 className="font-semibold mb-2">Supabase Integration</h3>
+            <div className={`p-2 rounded ${testResults.supabase?.success ? 'bg-green-100' : 'bg-red-100'}`}>
+              <pre className="text-sm">{JSON.stringify(testResults.supabase, null, 2)}</pre>
+            </div>
+          </div>
+
+          {testResults.error && (
+            <div className="border rounded p-4 bg-red-100">
+              <h3 className="font-semibold mb-2 text-red-800">Error</h3>
+              <pre className="text-sm text-red-800">{JSON.stringify(testResults.error, null, 2)}</pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="mt-6 p-4 bg-gray-100 rounded">
+        <h3 className="font-semibold mb-2">Environment Variables Status</h3>
+        <div className="text-sm space-y-1">
+          <div>VITE_SUPABASE_URL: {import.meta.env.VITE_SUPABASE_URL ? '✅ Set' : '❌ Not set'}</div>
+          <div>VITE_SUPABASE_ANON_KEY: {import.meta.env.VITE_SUPABASE_ANON_KEY ? '✅ Set' : '❌ Not set'}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+
+
+

--- a/src/components/MediaRecorderTest.tsx
+++ b/src/components/MediaRecorderTest.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const getSupportedMimeType = (): string | undefined => {
+  const types = [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/ogg;codecs=opus',
+    'audio/ogg',
+    'audio/mp4',
+    'audio/wav',
+  ];
+  // @ts-ignore - MediaRecorder may not exist at type time
+  if (typeof MediaRecorder === 'undefined') return undefined;
+  // @ts-ignore - isTypeSupported is static
+  for (const t of types) if ((MediaRecorder as any).isTypeSupported?.(t)) return t;
+  return undefined;
+};
+
+export default function MediaRecorderTest() {
+  const [hasSupport, setHasSupport] = useState<boolean>(false);
+  const [permission, setPermission] = useState<'unknown' | 'granted' | 'denied'>('unknown');
+  const [recording, setRecording] = useState(false);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [mimeType, setMimeType] = useState<string | undefined>(undefined);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<BlobPart[]>([]);
+
+  useEffect(() => {
+    // Detect availability
+    // @ts-ignore
+    setHasSupport(typeof MediaRecorder !== 'undefined');
+    setMimeType(getSupportedMimeType());
+
+    // Probe mic permission if supported
+    if (navigator.permissions && (navigator.permissions as any).query) {
+      (navigator.permissions as any)
+        .query({ name: 'microphone' as PermissionName })
+        .then((res: any) => setPermission(res.state))
+        .catch(() => setPermission('unknown'));
+    }
+  }, []);
+
+  const startRecording = async () => {
+    try {
+      setError(null);
+      setAudioUrl(null);
+      chunksRef.current = [];
+
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      // @ts-ignore
+      const rec = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+      mediaRecorderRef.current = rec;
+
+      rec.ondataavailable = (e: BlobEvent) => {
+        if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+      };
+
+      rec.onstop = () => {
+        try {
+          const blob = new Blob(chunksRef.current, { type: mimeType || 'audio/webm' });
+          const url = URL.createObjectURL(blob);
+          setAudioUrl(url);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Failed to create recording blob');
+        } finally {
+          if (streamRef.current) {
+            streamRef.current.getTracks().forEach(t => t.stop());
+            streamRef.current = null;
+          }
+        }
+      };
+
+      rec.start();
+      setRecording(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start recording');
+    }
+  };
+
+  const stopRecording = () => {
+    try {
+      mediaRecorderRef.current?.stop();
+      setRecording(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to stop recording');
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">MediaRecorder Test</h2>
+
+      <div className="mb-4 text-sm">
+        <div>Support: {hasSupport ? '✅ Yes' : '❌ No (polyfill should provide it)'}</div>
+        <div>Permission (probe): {permission}</div>
+        <div>Chosen MIME type: {mimeType || 'auto'}</div>
+      </div>
+
+      <div className="flex gap-2 mb-4">
+        <button
+          onClick={startRecording}
+          disabled={recording}
+          className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          Start Recording
+        </button>
+        <button
+          onClick={stopRecording}
+          disabled={!recording}
+          className="bg-red-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          Stop Recording
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-100 text-red-800 p-3 rounded mb-4 text-sm">{error}</div>
+      )}
+
+      {audioUrl && (
+        <div className="space-y-2">
+          <audio src={audioUrl} controls className="w-full" />
+          <a
+            href={audioUrl}
+            download={`recording-${Date.now()}.webm`}
+            className="inline-block bg-gray-200 px-3 py-1 rounded"
+          >
+            Download Recording
+          </a>
+        </div>
+      )}
+
+      <div className="mt-6 p-4 bg-gray-100 rounded text-sm">
+        <div>Debug:</div>
+        <pre className="whitespace-pre-wrap break-all">{JSON.stringify({
+          hasSupport,
+          permission,
+          mimeType,
+        }, null, 2)}</pre>
+      </div>
+    </div>
+  );
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/components/NetworkTest.tsx
+++ b/src/components/NetworkTest.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+
+export function NetworkTest() {
+  const [results, setResults] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  const testNetwork = async () => {
+    setLoading(true);
+    setResults({});
+
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    const tests = {};
+
+    try {
+      // Test 1: Basic fetch to Supabase URL
+      console.log('Testing basic fetch to:', supabaseUrl);
+      const response = await fetch(supabaseUrl);
+      tests.basicFetch = {
+        status: response.status,
+        ok: response.ok,
+        statusText: response.statusText
+      };
+    } catch (error) {
+      tests.basicFetch = { error: error.message };
+    }
+
+    try {
+      // Test 2: Fetch with auth headers
+      console.log('Testing auth endpoint...');
+      const authResponse = await fetch(`${supabaseUrl}/auth/v1/user`, {
+        headers: {
+          'apikey': import.meta.env.VITE_SUPABASE_ANON_KEY,
+          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
+        }
+      });
+      tests.authEndpoint = {
+        status: authResponse.status,
+        ok: authResponse.ok,
+        statusText: authResponse.statusText
+      };
+    } catch (error) {
+      tests.authEndpoint = { error: error.message };
+    }
+
+    try {
+      // Test 3: Test with Supabase client
+      console.log('Testing Supabase client...');
+      const { createClient } = await import('@supabase/supabase-js');
+      const supabase = createClient(supabaseUrl, import.meta.env.VITE_SUPABASE_ANON_KEY);
+      const { data, error } = await supabase.auth.getSession();
+      tests.supabaseClient = { data: !!data, error: error?.message };
+    } catch (error) {
+      tests.supabaseClient = { error: error.message };
+    }
+
+    setResults(tests);
+    setLoading(false);
+  };
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Network Connectivity Test</h2>
+      
+      <button
+        onClick={testNetwork}
+        disabled={loading}
+        className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50 mb-4"
+      >
+        {loading ? 'Testing...' : 'Test Network Connectivity'}
+      </button>
+
+      {results && (
+        <div className="space-y-4">
+          <div className="border rounded p-4">
+            <h3 className="font-semibold mb-2">Environment Variables:</h3>
+            <div className="text-sm space-y-1">
+              <div>URL: {import.meta.env.VITE_SUPABASE_URL || 'Not set'}</div>
+              <div>Key exists: {import.meta.env.VITE_SUPABASE_ANON_KEY ? 'Yes' : 'No'}</div>
+            </div>
+          </div>
+
+          <div className="border rounded p-4">
+            <h3 className="font-semibold mb-2">Test Results:</h3>
+            <pre className="text-sm bg-gray-100 p-2 rounded overflow-auto">
+              {JSON.stringify(results, null, 2)}
+            </pre>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 p-4 bg-yellow-100 rounded">
+        <h3 className="font-semibold mb-2">Troubleshooting Steps:</h3>
+        <ol className="text-sm space-y-1 list-decimal list-inside">
+          <li>Check if your Supabase project is active (not paused)</li>
+          <li>Verify the URL and key in your .env file</li>
+          <li>Check if you have internet connectivity</li>
+          <li>Try accessing Supabase dashboard directly</li>
+          <li>Check browser console for CORS errors</li>
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+
+
+
+

--- a/src/components/PeerTest.tsx
+++ b/src/components/PeerTest.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Peer, { MediaConnection } from 'peerjs';
+
+export default function PeerTest() {
+  const [peerId, setPeerId] = useState<string>('');
+  const [remoteId, setRemoteId] = useState<string>('');
+  const [status, setStatus] = useState<string>('Initializing...');
+  const [error, setError] = useState<string | null>(null);
+  const peerRef = useRef<Peer | null>(null);
+  const callRef = useRef<MediaConnection | null>(null);
+  const localAudioRef = useRef<HTMLAudioElement | null>(null);
+  const remoteAudioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const peer = new Peer({
+      debug: 2,
+    });
+    peerRef.current = peer;
+
+    peer.on('open', (id) => {
+      setPeerId(id);
+      setStatus('Ready');
+    });
+
+    peer.on('error', (err) => {
+      setError(err.message);
+      setStatus('Error');
+    });
+
+    peer.on('call', async (call) => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        call.answer(stream);
+        call.on('stream', (remoteStream) => {
+          if (remoteAudioRef.current) {
+            remoteAudioRef.current.srcObject = remoteStream;
+            remoteAudioRef.current.play().catch(() => {});
+          }
+        });
+        callRef.current = call;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to get local audio');
+      }
+    });
+
+    return () => {
+      try { callRef.current?.close(); } catch {}
+      try { peerRef.current?.destroy(); } catch {}
+    };
+  }, []);
+
+  const startCall = async () => {
+    setError(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const call = peerRef.current?.call(remoteId.trim(), stream);
+      if (!call) {
+        setError('Failed to start call');
+        return;
+      }
+      call.on('stream', (remoteStream) => {
+        if (remoteAudioRef.current) {
+          remoteAudioRef.current.srcObject = remoteStream;
+          remoteAudioRef.current.play().catch(() => {});
+        }
+      });
+      callRef.current = call;
+      setStatus('In call');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start call');
+    }
+  };
+
+  const endCall = () => {
+    try { callRef.current?.close(); } catch {}
+    callRef.current = null;
+    setStatus('Ready');
+  };
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">PeerJS WebRTC Test</h2>
+
+      <div className="mb-4 text-sm space-y-1">
+        <div>Status: {status}</div>
+        <div>Your Peer ID: <span className="font-mono bg-gray-100 px-2 py-0.5 rounded">{peerId || '...'}</span></div>
+      </div>
+
+      <div className="flex gap-2 mb-4">
+        <input
+          type="text"
+          placeholder="Remote Peer ID"
+          value={remoteId}
+          onChange={(e) => setRemoteId(e.target.value)}
+          className="flex-1 border rounded px-3 py-2"
+        />
+        <button onClick={startCall} className="bg-blue-600 text-white px-4 py-2 rounded">Call</button>
+        <button onClick={endCall} className="bg-gray-600 text-white px-4 py-2 rounded">End</button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4">
+        <div>
+          <div className="text-sm text-gray-600 mb-1">Local Audio (muted)</div>
+          <audio ref={localAudioRef} muted controls className="w-full" />
+        </div>
+        <div>
+          <div className="text-sm text-gray-600 mb-1">Remote Audio</div>
+          <audio ref={remoteAudioRef} controls className="w-full" />
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-4 p-3 bg-red-100 text-red-800 rounded text-sm">{error}</div>
+      )}
+
+      <div className="mt-6 p-3 bg-gray-100 rounded text-sm">
+        How to test:
+        <ol className="list-decimal ml-5 mt-1 space-y-1">
+          <li>Open this page in two tabs/devices.</li>
+          <li>Copy the Peer ID from Tab A and paste into Tab B, click Call.</li>
+          <li>Allow microphone permission. You should hear audio.</li>
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/components/SignupDebug.tsx
+++ b/src/components/SignupDebug.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { signUp, supabase } from '../lib/supabase';
+
+export function SignupDebug() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [result, setResult] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  const testSignup = async () => {
+    setLoading(true);
+    setResult(null);
+    
+    try {
+      console.log('=== SIGNUP DEBUG START ===');
+      console.log('Testing signup with:', { email, password, name });
+      console.log('Supabase URL:', import.meta.env.VITE_SUPABASE_URL);
+      console.log('Supabase Key exists:', !!import.meta.env.VITE_SUPABASE_ANON_KEY);
+      console.log('Supabase Key length:', import.meta.env.VITE_SUPABASE_ANON_KEY?.length);
+      
+      // Test basic Supabase connection first
+      console.log('Testing Supabase connection...');
+      const { data: testData, error: testError } = await supabase.auth.getSession();
+      console.log('Connection test result:', { testData, testError });
+      
+      // Now test signup
+      console.log('Testing signup...');
+      const response = await signUp(email, password, name);
+      console.log('Signup response:', response);
+      setResult(response);
+      
+      console.log('=== SIGNUP DEBUG END ===');
+    } catch (error) {
+      console.error('Signup test error:', error);
+      setResult({ 
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const testConnection = async () => {
+    try {
+      console.log('Testing basic Supabase connection...');
+      const { data, error } = await supabase.auth.getSession();
+      console.log('Connection result:', { data, error });
+      setResult({ connectionTest: { data, error } });
+    } catch (error) {
+      console.error('Connection test error:', error);
+      setResult({ connectionError: error });
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Signup Debug Test</h2>
+      
+      <div className="space-y-4 mb-6">
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <div className="flex space-x-2">
+          <button
+            onClick={testConnection}
+            className="bg-gray-500 text-white px-4 py-2 rounded"
+          >
+            Test Connection
+          </button>
+          <button
+            onClick={testSignup}
+            disabled={loading}
+            className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+          >
+            {loading ? 'Testing...' : 'Test Signup'}
+          </button>
+        </div>
+      </div>
+
+      {result && (
+        <div className="border rounded p-4">
+          <h3 className="font-semibold mb-2">Result:</h3>
+          <pre className="text-sm bg-gray-100 p-2 rounded overflow-auto max-h-96">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      <div className="mt-6 p-4 bg-gray-100 rounded">
+        <h3 className="font-semibold mb-2">Environment Variables:</h3>
+        <div className="text-sm space-y-1">
+          <div>VITE_SUPABASE_URL: {import.meta.env.VITE_SUPABASE_URL ? '✅ Set' : '❌ Not set'}</div>
+          <div>VITE_SUPABASE_ANON_KEY: {import.meta.env.VITE_SUPABASE_ANON_KEY ? '✅ Set' : '❌ Not set'}</div>
+          <div>URL Length: {import.meta.env.VITE_SUPABASE_URL?.length || 0}</div>
+          <div>Key Length: {import.meta.env.VITE_SUPABASE_ANON_KEY?.length || 0}</div>
+        </div>
+      </div>
+
+      <div className="mt-4 p-4 bg-yellow-100 rounded">
+        <h3 className="font-semibold mb-2">Instructions:</h3>
+        <ol className="text-sm space-y-1 list-decimal list-inside">
+          <li>Fill in the form above</li>
+          <li>Click "Test Connection" first to verify Supabase connection</li>
+          <li>Click "Test Signup" to test the signup process</li>
+          <li>Check the browser console (F12) for detailed logs</li>
+          <li>Share the results with me</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/FeedbackContext.tsx
+++ b/src/hooks/FeedbackContext.tsx
@@ -9,6 +9,14 @@ export interface Feedback {
   phonemeAccuracy: { value: number; text: string };
   suggestions: string[];
   date: string;
+  // Enhanced analysis fields (optional for backward compatibility)
+  transcription?: string;
+  confidenceScore?: number;
+  duration?: number;
+  wordsPerMinute?: number;
+  averagePitch?: number;
+  difficultyLevel?: 'easy' | 'medium' | 'hard';
+  masteryStatus?: 'learning' | 'practicing' | 'mastered';
 }
 
 interface FeedbackContextType {

--- a/src/hooks/VocabularyContext.tsx
+++ b/src/hooks/VocabularyContext.tsx
@@ -17,8 +17,28 @@ const VocabularyContext = createContext<VocabularyContextType | undefined>(undef
 
 const initialVocabList: VocabWord[] = [];
 
+// Load from localStorage on initialization
+const loadVocabFromStorage = (): VocabWord[] => {
+  try {
+    const stored = localStorage.getItem('vocabList');
+    return stored ? JSON.parse(stored) : initialVocabList;
+  } catch {
+    return initialVocabList;
+  }
+};
+
 export const VocabularyProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [vocabList, setVocabList] = useState<VocabWord[]>(initialVocabList);
+  const [vocabList, setVocabListState] = useState<VocabWord[]>(loadVocabFromStorage);
+
+  // Custom setter that also saves to localStorage
+  const setVocabList = (newList: VocabWord[]) => {
+    setVocabListState(newList);
+    try {
+      localStorage.setItem('vocabList', JSON.stringify(newList));
+    } catch (error) {
+      console.error('Failed to save vocab list to localStorage:', error);
+    }
+  };
   return (
     <VocabularyContext.Provider value={{ vocabList, setVocabList }}>
       {children}

--- a/src/lib/britannica.ts
+++ b/src/lib/britannica.ts
@@ -1,0 +1,38 @@
+export type BritannicaResult = {
+  title: string;
+  url: string;
+  snippet?: string;
+};
+
+// Britannica does not provide an open public API. This lightweight helper searches via SerpAPI
+// and filters results to encyclopedia Britannica, returning normalized results.
+// Requires VITE_SERPAPI_KEY (already supported via src/lib/serp.ts)
+import { serpSearch } from './serp';
+import { firecrawlSearch } from './firecrawl';
+
+export async function britannicaSearch(query: string, limit = 5): Promise<BritannicaResult[]> {
+  // 1) Try SerpAPI (fastest, most reliable when key is available)
+  try {
+    const serp = await serpSearch({ q: `${query} site:britannica.com OR site:kids.britannica.com`, num: limit, hl: 'en', gl: 'us' });
+    const viaSerp = (serp || [])
+      .filter(r => r.link && /(kids\.)?britannica\.com\//i.test(r.link))
+      .slice(0, limit)
+      .map(r => ({ title: r.title, url: r.link!, snippet: r.snippet }));
+    if (viaSerp.length > 0) return viaSerp;
+  } catch {}
+
+  // 2) Fallback to Firecrawl web search
+  try {
+    const q = `${query} site:britannica.com OR site:kids.britannica.com`;
+    const hits = await firecrawlSearch({ q, limit });
+    const viaFirecrawl = (hits || [])
+      .filter(h => h.url && /(kids\.)?britannica\.com\//i.test(h.url))
+      .slice(0, limit)
+      .map(h => ({ title: h.title || h.url, url: h.url, snippet: h.description }));
+    return viaFirecrawl;
+  } catch {}
+
+  return [];
+}
+
+

--- a/src/lib/elevenProxy.ts
+++ b/src/lib/elevenProxy.ts
@@ -1,0 +1,48 @@
+export async function ttsProxy(text: string, voiceId?: string): Promise<string | null> {
+  // Prefer local proxy; if unreachable, fall back to browser speech synthesis
+  const endpoint = (import.meta.env.VITE_PROXY_BASE || 'http://127.0.0.1:8787') + '/elevenlabs/tts';
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text, voiceId }),
+  });
+  if (!res.ok) {
+    try { console.error('TTS proxy error:', await res.text()); } catch {}
+    return null;
+  }
+  const buf = await res.arrayBuffer();
+  return URL.createObjectURL(new Blob([buf], { type: 'audio/mpeg' }));
+}
+
+export async function s2sProxy(audio: Blob, voiceId?: string): Promise<string | null> {
+  const endpoint = (import.meta.env.VITE_PROXY_BASE || 'http://localhost:8787') + '/elevenlabs/s2s';
+  const form = new FormData();
+  const filename = audio.type && audio.type.includes('wav') ? 'audio.wav' : 'audio.webm';
+  form.append('file', audio, filename);
+  if (voiceId) form.append('voiceId', voiceId);
+  let res: Response;
+  try {
+    res = await fetch(endpoint, { method: 'POST', body: form });
+  } catch (e) {
+    console.error('S2S fetch failed (is proxy running?):', e);
+    // Probe health endpoint to provide a clearer message in console
+    try {
+      const health = await fetch((import.meta.env.VITE_PROXY_BASE || 'http://localhost:8787') + '/elevenlabs/health').then(r => r.json());
+      console.error('Proxy health:', health);
+    } catch {}
+    return null;
+  }
+  if (!res.ok) {
+    try { console.error('S2S proxy error:', await res.text()); } catch {}
+    return null;
+  }
+  const buf = await res.arrayBuffer();
+  return URL.createObjectURL(new Blob([buf], { type: 'audio/mpeg' }));
+}
+
+
+
+
+
+
+

--- a/src/lib/firecrawl.ts
+++ b/src/lib/firecrawl.ts
@@ -1,0 +1,123 @@
+export type FirecrawlSearchParams = {
+  q: string;
+  limit?: number;
+  page?: number;
+};
+
+export type FirecrawlSearchResult = {
+  title?: string;
+  url: string;
+  description?: string;
+  source?: string;
+};
+
+export type FirecrawlScrapeOptions = {
+  url: string;
+  formats?: Array<'markdown' | 'html' | 'raw' | 'links'>;
+};
+
+export type FirecrawlScrapeResponse = {
+  markdown?: string;
+  html?: string;
+  raw?: any;
+  links?: Array<{ url: string; text?: string }>;
+  meta?: Record<string, any>;
+};
+
+const getBaseUrl = () => (import.meta as any).env.VITE_FIRECRAWL_BASE || 'https://api.firecrawl.dev';
+const getApiKey = () => (import.meta as any).env.VITE_FIRECRAWL_API_KEY as string | undefined;
+
+async function firecrawlFetch(path: string, body: any) {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    console.warn('VITE_FIRECRAWL_API_KEY is not set. Firecrawl calls will be skipped.');
+    return null;
+  }
+  const base = getBaseUrl().replace(/\/$/, '');
+  const url = `${base}${path}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'x-api-key': apiKey,
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    try {
+      const txt = await res.text();
+      console.warn('Firecrawl error', res.status, txt);
+    } catch {}
+    return null;
+  }
+  try { return await res.json(); } catch { return null; }
+}
+
+async function firecrawlGet(path: string, params: Record<string, any>) {
+  const apiKey = getApiKey();
+  if (!apiKey) return null;
+  const base = getBaseUrl().replace(/\/$/, '');
+  const query = new URLSearchParams(params as any).toString();
+  const url = `${base}${path}?${query}`;
+  const res = await fetch(url, {
+    headers: {
+      'Accept': 'application/json',
+      'x-api-key': apiKey,
+      'Authorization': `Bearer ${apiKey}`,
+    }
+  });
+  if (!res.ok) return null;
+  try { return await res.json(); } catch { return null; }
+}
+
+export async function firecrawlSearch(params: FirecrawlSearchParams): Promise<FirecrawlSearchResult[]> {
+  let json = await firecrawlFetch('/v1/search', {
+    query: params.q,
+    limit: params.limit ?? 10,
+    page: params.page ?? 1,
+  });
+  if (!json) {
+    // Fallback to GET variant if POST is not supported on the account
+    json = await firecrawlGet('/v1/search', {
+      q: params.q,
+      limit: params.limit ?? 10,
+      page: params.page ?? 1,
+    });
+  }
+  if (!json) return [];
+  const items: any[] = json.results || json.data || [];
+  return items.map((r: any) => ({
+    title: r.title || r.meta_title,
+    url: r.url || r.link,
+    description: r.description || r.snippet,
+    source: r.source,
+  })).filter((r: any) => r.url);
+}
+
+export async function firecrawlScrape(options: FirecrawlScrapeOptions): Promise<FirecrawlScrapeResponse | null> {
+  const { url, formats = ['markdown', 'links'] } = options;
+  const json = await firecrawlFetch('/v1/scrape', {
+    url,
+    formats,
+  });
+  if (!json) return null;
+  return {
+    markdown: json.markdown,
+    html: json.html,
+    raw: json.raw,
+    links: json.links,
+    meta: json.meta,
+  } as FirecrawlScrapeResponse;
+}
+
+export async function firecrawlCrawl(startUrl: string, limit = 10) {
+  const json = await firecrawlFetch('/v1/crawl', {
+    url: startUrl,
+    limit,
+  });
+  if (!json) return [];
+  const pages: any[] = json.pages || json.results || [];
+  return pages;
+}

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,0 +1,181 @@
+export type DebateInsights = {
+  topic: string;
+  sentiment: 'positive' | 'neutral' | 'negative';
+  argumentStrength: { builder: number; breaker: number; rationale: string };
+  keyPoints: string[];
+  grammarIssues: Array<{ excerpt: string; issue: string; suggestion: string }>;
+};
+
+export type VocabInsights = {
+  overallAccuracy: number;
+  commonErrors: string[];
+  practiceSuggestions: string[];
+};
+
+async function callOpenAI(messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>): Promise<any | null> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY as string | undefined;
+  const proxy = import.meta.env.VITE_OPENAI_PROXY as string | undefined;
+  const url = (proxy || 'https://api.openai.com') + '/v1/chat/completions';
+  if (!apiKey && !proxy) return null;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages,
+        response_format: { type: 'json_object' },
+        temperature: 0.2,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content;
+    if (!text) return null;
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+export async function analyzeDebateTranscript(transcript: string, topic: string): Promise<DebateInsights | null> {
+  const system = {
+    role: 'system' as const,
+    content:
+      'You are an expert debate coach. Return ONLY JSON with keys: topic, sentiment (positive|neutral|negative), argumentStrength {builder: 0-100, breaker: 0-100, rationale}, keyPoints (array of short strings), grammarIssues (array of {excerpt, issue, suggestion}).',
+  };
+  const user = {
+    role: 'user' as const,
+    content: `Topic: ${topic}\nTranscript:\n${transcript}`,
+  };
+  const json = await callOpenAI([system, user]);
+  return json as DebateInsights | null;
+}
+
+export async function analyzeVocabularyAnswers(answers: Array<{ prompt: string; user: string }>): Promise<VocabInsights | null> {
+  const system = {
+    role: 'system' as const,
+    content:
+      'You are a language tutor. Return ONLY JSON with keys: overallAccuracy (0-100), commonErrors (array), practiceSuggestions (array).',
+  };
+  const user = {
+    role: 'user' as const,
+    content: `Assess these vocabulary attempts: ${JSON.stringify(answers).slice(0, 8000)}`,
+  };
+  const json = await callOpenAI([system, user]);
+  return json as VocabInsights | null;
+}
+
+export async function generateSpeakingParagraphs(
+  title: string,
+  ageGroup: string,
+  proficiencyLevel: string,
+  curriculum?: string
+): Promise<string | null> {
+  const system = {
+    role: 'system' as const,
+    content:
+      'You are a creative ESL speech coach. Write 2-3 short paragraphs for speaking practice using vivid, age-appropriate, imaginative language. Use simple stage directions (e.g., [Pause], [Emphasize]) sparingly. Output only plain text.'
+  };
+  const user = {
+    role: 'user' as const,
+    content: `Title: ${title}\nAudience: ${ageGroup}\nLevel: ${proficiencyLevel}${curriculum ? `\nCurriculum: ${curriculum}` : ''}\nTask: Generate 2-3 short, engaging paragraphs for a kid to speak aloud.`
+  };
+  const json = await callOpenAI([system, user]);
+  // callOpenAI enforces JSON response_format; for this endpoint we want text.
+  // If the proxy responds with a JSON string under {text}, handle both cases.
+  if (!json) return null;
+  if (typeof json === 'string') return json;
+  if (json.text) return json.text as string;
+  // Fallback: stringify minimal
+  try { return JSON.stringify(json); } catch { return null; }
+}
+
+// Generate detailed creative notes with structured sections (Introduction, Beginner, Middle, Conclusion)
+export async function generateStructuredNotes(
+  title: string,
+  baseContent: string,
+  ageGroup: string,
+  proficiencyLevel: string,
+  curriculum?: string
+): Promise<string | null> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY as string | undefined;
+  const proxy = import.meta.env.VITE_OPENAI_PROXY as string | undefined;
+  const url = (proxy || 'https://api.openai.com') + '/v1/chat/completions';
+  if (!apiKey && !proxy) return null;
+
+  const system = {
+    role: 'system',
+    content:
+      'You are a master ESL content writer and storyteller. ALWAYS produce vivid, student-friendly notes in EXACTLY four sections: Introduction, Beginner, Middle, Conclusion. Use imaginative and creative language (metaphors, kid-friendly analogies), while being clear and accurate. Output plain text ONLY (no markdown headings beyond the section titles).'
+  } as const;
+  const user = {
+    role: 'user',
+    content:
+      `Title: ${title}
+Audience: ${ageGroup}
+Level: ${proficiencyLevel}${curriculum ? `\nCurriculum: ${curriculum}` : ''}
+Source content (may be rough markdown/links). If short or low-quality, expand with your own knowledge while keeping it age-appropriate:\n${baseContent.slice(0, 6000)}\n
+Task: Return four sections with BLANK LINES between them. Use the following structure and length targets:
+Introduction: 3–4 sentences (70–120 words). Give a vivid hook and define the topic simply.
+Beginner: 5–7 short bullets. Explain basics with friendly examples and a micro-activity.
+Middle: 2 paragraphs (120–200 words total). Add a creative analogy or mini-story + one hands-on activity idea.
+Conclusion: 3 bullets of key takeaways + 1 short challenge question.
+
+Write in lively, positive tone. Avoid repetition. Plain text only (no JSON).`
+  } as const;
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [system, user],
+        temperature: 0.8,
+        max_tokens: 1200,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content as string | undefined;
+    return text || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function transcribeAudioWhisper(audio: Blob): Promise<string | null> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY as string | undefined;
+  const proxy = import.meta.env.VITE_OPENAI_PROXY as string | undefined;
+  const url = (proxy || 'https://api.openai.com') + '/v1/audio/transcriptions';
+  if (!apiKey && !proxy) return null;
+
+  const form = new FormData();
+  form.append('file', audio, 'recording.webm');
+  form.append('model', 'whisper-1');
+  form.append('response_format', 'text');
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: form,
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    return text;
+  } catch {
+    return null;
+  }
+}
+
+

--- a/src/lib/languageTool.ts
+++ b/src/lib/languageTool.ts
@@ -1,0 +1,53 @@
+export type LTMatch = {
+  message: string;
+  offset: number;
+  length: number;
+  sentence: string;
+  ruleId: string;
+  replacements: string[];
+};
+
+export async function checkGrammarLanguageTool(
+  text: string,
+  language: string = 'en-US'
+): Promise<LTMatch[] | null> {
+  if (!text || !text.trim()) return [];
+
+  const base = (import.meta.env.VITE_LT_API_URL as string) || 'https://api.languagetool.org';
+  const url = `${base.replace(/\/$/, '')}/v2/check`;
+
+  const params = new URLSearchParams();
+  params.set('text', text);
+  params.set('language', language);
+  // enable both grammar and style
+  params.set('enabledOnly', 'false');
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/x-www-form-urlencoded',
+  };
+
+  // Optional bearer for LT Cloud (e.g., https://api.languagetoolplus.com)
+  const bearer = import.meta.env.VITE_LT_BEARER_TOKEN as string | undefined;
+  if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
+
+  try {
+    const res = await fetch(url, { method: 'POST', headers, body: params });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const matches = (json.matches || []) as any[];
+    return matches.map((m) => ({
+      message: m.message,
+      offset: m.offset,
+      length: m.length,
+      sentence: m.sentence || '',
+      ruleId: m.rule?.id || '',
+      replacements: (m.replacements || []).slice(0, 5).map((r: any) => r.value),
+    }));
+  } catch {
+    return null;
+  }
+}
+
+
+
+

--- a/src/lib/pdfExport.ts
+++ b/src/lib/pdfExport.ts
@@ -1,0 +1,611 @@
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
+
+export interface PronunciationReportData {
+  userName: string;
+  reportDate: string;
+  overallScore: number;
+  totalWords: number;
+  totalRecordings: number;
+  timeSpent: number; // in minutes
+  
+  // Detailed metrics
+  pronunciationScores: Array<{
+    word: string;
+    score: number;
+    attempts: number;
+    difficulty: 'easy' | 'medium' | 'hard';
+  }>;
+  
+  phonemeAccuracy: Array<{
+    phoneme: string;
+    accuracy: number;
+  }>;
+  
+  progressData: Array<{
+    date: string;
+    score: number;
+    wordsPerMinute: number;
+  }>;
+  
+  communicationStyle: {
+    clarity: number;
+    fluency: number;
+    intonation: number;
+    speakingRate: 'slow' | 'normal' | 'fast';
+  };
+  
+  achievements: string[];
+  focusAreas: string[];
+  recommendations: string[];
+}
+
+class PDFExportService {
+  // Generate comprehensive pronunciation insights PDF
+  async generatePronunciationReport(data: PronunciationReportData): Promise<Blob> {
+    try {
+      // Create a temporary container for the report
+      const reportContainer = this.createReportHTML(data);
+      document.body.appendChild(reportContainer);
+      
+      // Wait for any dynamic content to load
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      // Generate PDF using html2canvas + jsPDF
+      const pdf = await this.htmlToPDF(reportContainer);
+      
+      // Clean up
+      document.body.removeChild(reportContainer);
+      
+      return pdf;
+    } catch (error) {
+      console.error('Error generating PDF report:', error);
+      throw new Error('Failed to generate PDF report');
+    }
+  }
+
+  // Create HTML structure for the report
+  private createReportHTML(data: PronunciationReportData): HTMLElement {
+    const container = document.createElement('div');
+    container.style.cssText = `
+      width: 210mm;
+      min-height: 297mm;
+      padding: 20mm;
+      margin: 0 auto;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      position: absolute;
+      top: -10000px;
+      left: -10000px;
+    `;
+
+    container.innerHTML = `
+      <!-- Header Section -->
+      <div style="text-align: center; margin-bottom: 40px; padding: 30px; background: rgba(255,255,255,0.1); border-radius: 20px; backdrop-filter: blur(10px);">
+        <h1 style="font-size: 36px; font-weight: bold; margin: 0; text-shadow: 2px 2px 4px rgba(0,0,0,0.3);">
+          VocabPro Pronunciation Report
+        </h1>
+        <p style="font-size: 18px; margin: 10px 0; opacity: 0.9;">
+          Comprehensive Analysis for ${data.userName}
+        </p>
+        <p style="font-size: 14px; margin: 0; opacity: 0.7;">
+          Generated on ${new Date(data.reportDate).toLocaleDateString('en-US', { 
+            year: 'numeric', 
+            month: 'long', 
+            day: 'numeric' 
+          })}
+        </p>
+      </div>
+
+      <!-- Executive Summary -->
+      <div style="margin-bottom: 40px;">
+        <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 20px; border-bottom: 2px solid rgba(255,255,255,0.3); padding-bottom: 10px;">
+          📊 Executive Summary
+        </h2>
+        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; margin-bottom: 20px;">
+          <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px; text-align: center;">
+            <div style="font-size: 32px; font-weight: bold; color: #4ade80;">${Math.round(data.overallScore * 100)}%</div>
+            <div style="font-size: 14px; opacity: 0.8;">Overall Score</div>
+          </div>
+          <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px; text-align: center;">
+            <div style="font-size: 32px; font-weight: bold; color: #60a5fa;">${data.totalWords}</div>
+            <div style="font-size: 14px; opacity: 0.8;">Words Practiced</div>
+          </div>
+          <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px; text-align: center;">
+            <div style="font-size: 32px; font-weight: bold; color: #f472b6;">${data.totalRecordings}</div>
+            <div style="font-size: 14px; opacity: 0.8;">Total Recordings</div>
+          </div>
+          <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px; text-align: center;">
+            <div style="font-size: 32px; font-weight: bold; color: #fbbf24;">${Math.round(data.timeSpent)}</div>
+            <div style="font-size: 14px; opacity: 0.8;">Minutes Practiced</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Word Performance Analysis -->
+      <div style="margin-bottom: 40px;">
+        <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 20px; border-bottom: 2px solid rgba(255,255,255,0.3); padding-bottom: 10px;">
+          🎯 Word Performance Analysis
+        </h2>
+        <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px;">
+          <table style="width: 100%; border-collapse: collapse;">
+            <thead>
+              <tr style="border-bottom: 1px solid rgba(255,255,255,0.3);">
+                <th style="text-align: left; padding: 12px; font-weight: bold;">Word</th>
+                <th style="text-align: center; padding: 12px; font-weight: bold;">Score</th>
+                <th style="text-align: center; padding: 12px; font-weight: bold;">Attempts</th>
+                <th style="text-align: center; padding: 12px; font-weight: bold;">Difficulty</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${data.pronunciationScores.map(word => `
+                <tr style="border-bottom: 1px solid rgba(255,255,255,0.1);">
+                  <td style="padding: 12px; font-weight: 500;">${word.word}</td>
+                  <td style="text-align: center; padding: 12px;">
+                    <span style="color: ${this.getScoreColor(word.score)}; font-weight: bold;">
+                      ${Math.round(word.score * 100)}%
+                    </span>
+                  </td>
+                  <td style="text-align: center; padding: 12px;">${word.attempts}</td>
+                  <td style="text-align: center; padding: 12px;">
+                    <span style="background: ${this.getDifficultyColor(word.difficulty)}; padding: 4px 8px; border-radius: 8px; font-size: 12px; font-weight: bold;">
+                      ${word.difficulty.toUpperCase()}
+                    </span>
+                  </td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Communication Style Analysis -->
+      <div style="margin-bottom: 40px;">
+        <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 20px; border-bottom: 2px solid rgba(255,255,255,0.3); padding-bottom: 10px;">
+          🗣️ Communication Style Analysis
+        </h2>
+        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px;">
+          <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px;">
+            <h3 style="font-size: 18px; font-weight: bold; margin-bottom: 15px;">Speaking Metrics</h3>
+            <div style="margin-bottom: 10px;">
+              <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                <span>Clarity</span>
+                <span style="font-weight: bold; color: #4ade80;">${Math.round(data.communicationStyle.clarity * 100)}%</span>
+              </div>
+              <div style="background: rgba(255,255,255,0.2); height: 8px; border-radius: 4px;">
+                <div style="background: #4ade80; height: 100%; width: ${data.communicationStyle.clarity * 100}%; border-radius: 4px;"></div>
+              </div>
+            </div>
+            <div style="margin-bottom: 10px;">
+              <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                <span>Fluency</span>
+                <span style="font-weight: bold; color: #60a5fa;">${Math.round(data.communicationStyle.fluency * 100)}%</span>
+              </div>
+              <div style="background: rgba(255,255,255,0.2); height: 8px; border-radius: 4px;">
+                <div style="background: #60a5fa; height: 100%; width: ${data.communicationStyle.fluency * 100}%; border-radius: 4px;"></div>
+              </div>
+            </div>
+            <div style="margin-bottom: 10px;">
+              <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                <span>Intonation</span>
+                <span style="font-weight: bold; color: #f472b6;">${Math.round(data.communicationStyle.intonation * 100)}%</span>
+              </div>
+              <div style="background: rgba(255,255,255,0.2); height: 8px; border-radius: 4px;">
+                <div style="background: #f472b6; height: 100%; width: ${data.communicationStyle.intonation * 100}%; border-radius: 4px;"></div>
+              </div>
+            </div>
+          </div>
+          <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px;">
+            <h3 style="font-size: 18px; font-weight: bold; margin-bottom: 15px;">Speaking Rate</h3>
+            <div style="text-align: center; padding: 20px;">
+              <div style="font-size: 36px; font-weight: bold; color: #fbbf24; margin-bottom: 10px;">
+                ${data.communicationStyle.speakingRate.toUpperCase()}
+              </div>
+              <p style="opacity: 0.8; margin: 0;">
+                ${this.getSpeakingRateDescription(data.communicationStyle.speakingRate)}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Achievements and Focus Areas -->
+      <div style="margin-bottom: 40px;">
+        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px;">
+          <div>
+            <h2 style="font-size: 20px; font-weight: bold; margin-bottom: 15px; color: #4ade80;">
+              🏆 Achievements
+            </h2>
+            <div style="background: rgba(74, 222, 128, 0.1); padding: 20px; border-radius: 15px; border: 1px solid rgba(74, 222, 128, 0.3);">
+              ${data.achievements.length > 0 ? 
+                data.achievements.map(achievement => `
+                  <div style="display: flex; align-items: center; margin-bottom: 10px;">
+                    <span style="margin-right: 10px;">✅</span>
+                    <span>${achievement}</span>
+                  </div>
+                `).join('') : 
+                '<p style="opacity: 0.7; margin: 0;">Keep practicing to unlock achievements!</p>'
+              }
+            </div>
+          </div>
+          <div>
+            <h2 style="font-size: 20px; font-weight: bold; margin-bottom: 15px; color: #f59e0b;">
+              🎯 Focus Areas
+            </h2>
+            <div style="background: rgba(245, 158, 11, 0.1); padding: 20px; border-radius: 15px; border: 1px solid rgba(245, 158, 11, 0.3);">
+              ${data.focusAreas.length > 0 ? 
+                data.focusAreas.map(area => `
+                  <div style="display: flex; align-items: center; margin-bottom: 10px;">
+                    <span style="margin-right: 10px;">🔍</span>
+                    <span>${area}</span>
+                  </div>
+                `).join('') : 
+                '<p style="opacity: 0.7; margin: 0;">Great job! No specific focus areas identified.</p>'
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Recommendations -->
+      <div style="margin-bottom: 40px;">
+        <h2 style="font-size: 24px; font-weight: bold; margin-bottom: 20px; border-bottom: 2px solid rgba(255,255,255,0.3); padding-bottom: 10px;">
+          💡 Personalized Recommendations
+        </h2>
+        <div style="background: rgba(255,255,255,0.1); padding: 20px; border-radius: 15px;">
+          ${data.recommendations.map((rec, index) => `
+            <div style="display: flex; align-items: flex-start; margin-bottom: 15px;">
+              <span style="background: #667eea; color: white; border-radius: 50%; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; font-weight: bold; font-size: 12px; margin-right: 15px; flex-shrink: 0;">
+                ${index + 1}
+              </span>
+              <p style="margin: 0; line-height: 1.6;">${rec}</p>
+            </div>
+          `).join('')}
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div style="text-align: center; padding: 20px; margin-top: 40px; border-top: 1px solid rgba(255,255,255,0.3);">
+        <p style="margin: 0; opacity: 0.7; font-size: 14px;">
+          Generated by VocabPro AI • Continue practicing to improve your pronunciation skills!
+        </p>
+      </div>
+    `;
+
+    return container;
+  }
+
+  // Convert HTML element to PDF using html2canvas + jsPDF
+  private async htmlToPDF(element: HTMLElement): Promise<Blob> {
+    try {
+      // Capture the element as canvas
+      const canvas = await html2canvas(element, {
+        scale: 2, // Higher resolution
+        useCORS: true,
+        allowTaint: true,
+        backgroundColor: null,
+        logging: false,
+      });
+
+      // Create PDF
+      const pdf = new jsPDF({
+        orientation: 'portrait',
+        unit: 'mm',
+        format: 'a4',
+      });
+
+      // Calculate dimensions
+      const imgWidth = 210; // A4 width in mm
+      const imgHeight = (canvas.height * imgWidth) / canvas.width;
+      
+      // Add image to PDF
+      pdf.addImage(
+        canvas.toDataURL('image/png'),
+        'PNG',
+        0,
+        0,
+        imgWidth,
+        imgHeight,
+        undefined,
+        'FAST'
+      );
+
+      // Return as blob
+      return new Promise((resolve) => {
+        pdf.output('blob').then((blob: Blob) => resolve(blob));
+      });
+    } catch (error) {
+      console.error('Error converting HTML to PDF:', error);
+      throw error;
+    }
+  }
+
+  // Helper method to get color based on score
+  private getScoreColor(score: number): string {
+    if (score >= 0.8) return '#4ade80'; // Green
+    if (score >= 0.6) return '#fbbf24'; // Yellow
+    return '#f87171'; // Red
+  }
+
+  // Helper method to get difficulty color
+  private getDifficultyColor(difficulty: string): string {
+    switch (difficulty) {
+      case 'easy': return '#4ade80';
+      case 'medium': return '#fbbf24';
+      case 'hard': return '#f87171';
+      default: return '#6b7280';
+    }
+  }
+
+  // Helper method to get speaking rate description
+  private getSpeakingRateDescription(rate: string): string {
+    switch (rate) {
+      case 'slow': return 'Take your time to articulate clearly';
+      case 'fast': return 'Consider slowing down for better clarity';
+      case 'normal': return 'Perfect speaking pace!';
+      default: return 'Keep practicing!';
+    }
+  }
+
+  // Quick export function for download - simplified version with timeout
+  async downloadReport(data: PronunciationReportData, filename?: string): Promise<void> {
+    // Set a 10-second timeout to prevent getting stuck
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('PDF export timeout')), 10000);
+    });
+
+    const exportPromise = (async () => {
+      try {
+        console.log('Creating PDF document...');
+        
+        // Create a simpler PDF without html2canvas to avoid getting stuck
+        const pdf = new jsPDF({
+          orientation: 'portrait',
+          unit: 'mm',
+          format: 'a4',
+        });
+
+        console.log('Adding content to PDF...');
+        
+        // Add content directly to PDF
+        this.addTextToPDF(pdf, data);
+
+        console.log('Saving PDF...');
+        
+        // Save the PDF
+        const pdfName = filename || `pronunciation-report-${data.userName.replace(/\s+/g, '-')}-${new Date().toISOString().split('T')[0]}.pdf`;
+        pdf.save(pdfName);
+        
+        console.log('PDF saved successfully:', pdfName);
+        
+      } catch (error) {
+        console.error('Error in PDF generation:', error);
+        throw error;
+      }
+    })();
+
+    try {
+      await Promise.race([exportPromise, timeoutPromise]);
+    } catch (error) {
+      console.error('PDF export failed, using fallback:', error);
+      // Fallback: create a simple text-based report
+      this.createFallbackReport(data);
+    }
+  }
+
+  // Add text content directly to PDF (faster and more reliable)
+  private addTextToPDF(pdf: jsPDF, data: PronunciationReportData): void {
+    let yPos = 20;
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const margin = 20;
+    const contentWidth = pageWidth - (margin * 2);
+
+    // Header
+    pdf.setFontSize(24);
+    pdf.setTextColor(0, 100, 200);
+    pdf.text('VocabPro Pronunciation Report', pageWidth / 2, yPos, { align: 'center' });
+    yPos += 15;
+
+    pdf.setFontSize(14);
+    pdf.setTextColor(100, 100, 100);
+    pdf.text(`Comprehensive Analysis for ${data.userName}`, pageWidth / 2, yPos, { align: 'center' });
+    yPos += 10;
+
+    pdf.setFontSize(12);
+    pdf.text(`Generated on ${new Date(data.reportDate).toLocaleDateString()}`, pageWidth / 2, yPos, { align: 'center' });
+    yPos += 25;
+
+    // Executive Summary
+    pdf.setFontSize(18);
+    pdf.setTextColor(0, 0, 0);
+    pdf.text('📊 Executive Summary', margin, yPos);
+    yPos += 15;
+
+    pdf.setFontSize(12);
+    const summaryData = [
+      `Overall Score: ${Math.round(data.overallScore * 100)}%`,
+      `Words Practiced: ${data.totalWords}`,
+      `Total Recordings: ${data.totalRecordings}`,
+      `Practice Time: ${Math.round(data.timeSpent)} minutes`
+    ];
+
+    summaryData.forEach(item => {
+      pdf.text(`• ${item}`, margin + 5, yPos);
+      yPos += 8;
+    });
+    yPos += 10;
+
+    // Word Performance
+    if (data.pronunciationScores.length > 0) {
+      pdf.setFontSize(16);
+      pdf.text('🎯 Word Performance Analysis', margin, yPos);
+      yPos += 12;
+
+      pdf.setFontSize(10);
+      data.pronunciationScores.slice(0, 10).forEach(word => { // Limit to first 10 words
+        const scoreText = `${word.word}: ${Math.round(word.score * 100)}% (${word.difficulty})`;
+        pdf.text(`• ${scoreText}`, margin + 5, yPos);
+        yPos += 6;
+      });
+      yPos += 10;
+    }
+
+    // Communication Style
+    pdf.setFontSize(16);
+    pdf.text('🗣️ Communication Style', margin, yPos);
+    yPos += 12;
+
+    pdf.setFontSize(12);
+    const styleData = [
+      `Clarity: ${Math.round(data.communicationStyle.clarity * 100)}%`,
+      `Fluency: ${Math.round(data.communicationStyle.fluency * 100)}%`,
+      `Intonation: ${Math.round(data.communicationStyle.intonation * 100)}%`,
+      `Speaking Rate: ${data.communicationStyle.speakingRate}`
+    ];
+
+    styleData.forEach(item => {
+      pdf.text(`• ${item}`, margin + 5, yPos);
+      yPos += 8;
+    });
+    yPos += 15;
+
+    // Achievements
+    if (data.achievements.length > 0) {
+      pdf.setFontSize(16);
+      pdf.setTextColor(0, 150, 0);
+      pdf.text('🏆 Achievements', margin, yPos);
+      yPos += 12;
+
+      pdf.setFontSize(12);
+      pdf.setTextColor(0, 0, 0);
+      data.achievements.forEach(achievement => {
+        pdf.text(`✅ ${achievement}`, margin + 5, yPos);
+        yPos += 8;
+      });
+      yPos += 10;
+    }
+
+    // Focus Areas
+    if (data.focusAreas.length > 0) {
+      pdf.setFontSize(16);
+      pdf.setTextColor(200, 100, 0);
+      pdf.text('🎯 Focus Areas', margin, yPos);
+      yPos += 12;
+
+      pdf.setFontSize(12);
+      pdf.setTextColor(0, 0, 0);
+      data.focusAreas.forEach(area => {
+        pdf.text(`🔍 ${area}`, margin + 5, yPos);
+        yPos += 8;
+      });
+      yPos += 15;
+    }
+
+    // Recommendations
+    pdf.setFontSize(16);
+    pdf.setTextColor(0, 0, 200);
+    pdf.text('💡 Recommendations', margin, yPos);
+    yPos += 12;
+
+    pdf.setFontSize(11);
+    pdf.setTextColor(0, 0, 0);
+    data.recommendations.forEach((rec, index) => {
+      const lines = pdf.splitTextToSize(`${index + 1}. ${rec}`, contentWidth - 10);
+      lines.forEach((line: string) => {
+        if (yPos > 270) { // Check if we need a new page
+          pdf.addPage();
+          yPos = 20;
+        }
+        pdf.text(line, margin + 5, yPos);
+        yPos += 6;
+      });
+      yPos += 3;
+    });
+
+    // Footer
+    pdf.setFontSize(10);
+    pdf.setTextColor(100, 100, 100);
+    pdf.text('Generated by VocabPro AI • Continue practicing to improve!', pageWidth / 2, 280, { align: 'center' });
+  }
+
+  // Fallback method if PDF generation fails
+  private createFallbackReport(data: PronunciationReportData): void {
+    const reportContent = `
+VocabPro Pronunciation Report
+============================
+User: ${data.userName}
+Date: ${new Date(data.reportDate).toLocaleDateString()}
+
+EXECUTIVE SUMMARY
+================
+Overall Score: ${Math.round(data.overallScore * 100)}%
+Words Practiced: ${data.totalWords}
+Total Recordings: ${data.totalRecordings}
+Practice Time: ${Math.round(data.timeSpent)} minutes
+
+COMMUNICATION STYLE
+==================
+Clarity: ${Math.round(data.communicationStyle.clarity * 100)}%
+Fluency: ${Math.round(data.communicationStyle.fluency * 100)}%
+Intonation: ${Math.round(data.communicationStyle.intonation * 100)}%
+Speaking Rate: ${data.communicationStyle.speakingRate}
+
+ACHIEVEMENTS
+===========
+${data.achievements.map(a => `✅ ${a}`).join('\n')}
+
+FOCUS AREAS
+===========
+${data.focusAreas.map(a => `🎯 ${a}`).join('\n')}
+
+RECOMMENDATIONS
+==============
+${data.recommendations.map((r, i) => `${i + 1}. ${r}`).join('\n')}
+
+Generated by VocabPro AI
+    `.trim();
+
+    // Create and download as text file
+    const blob = new Blob([reportContent], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `pronunciation-report-${data.userName.replace(/\s+/g, '-')}-${new Date().toISOString().split('T')[0]}.txt`;
+    
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    
+    URL.revokeObjectURL(url);
+  }
+
+  // Share report via native Web Share API
+  async shareReport(data: PronunciationReportData): Promise<void> {
+    try {
+      const pdfBlob = await this.generatePronunciationReport(data);
+      const file = new File([pdfBlob], `pronunciation-report-${data.userName}.pdf`, {
+        type: 'application/pdf'
+      });
+
+      if (navigator.canShare && navigator.canShare({ files: [file] })) {
+        await navigator.share({
+          title: 'VocabPro Pronunciation Report',
+          text: `Check out my pronunciation progress report from VocabPro!`,
+          files: [file]
+        });
+      } else {
+        // Fallback to download
+        await this.downloadReport(data);
+      }
+    } catch (error) {
+      console.error('Error sharing report:', error);
+      // Fallback to download
+      await this.downloadReport(data);
+    }
+  }
+}
+
+export const pdfExportService = new PDFExportService();
+

--- a/src/lib/pronunciationAnalysis.ts
+++ b/src/lib/pronunciationAnalysis.ts
@@ -1,0 +1,647 @@
+import { supabase } from './supabase';
+
+export interface PronunciationAnalysis {
+  // Basic Info
+  word: string;
+  transcription: string;
+  confidenceScore: number;
+  
+  // Audio Metrics
+  duration: number;
+  wordCount: number;
+  wordsPerMinute: number;
+  
+  // Voice Characteristics
+  averagePitch: number;
+  pitchRange: number;
+  volume: number;
+  
+  // Pronunciation Assessment
+  phonemeAccuracy: Record<string, number>;
+  pronunciationErrors: string[];
+  
+  // Communication Style
+  speakingRate: 'slow' | 'normal' | 'fast';
+  clarityScore: number;
+  fluencyScore: number;
+  intonationScore: number;
+  
+  // Overall Assessment
+  overallScore: number;
+  improvementSuggestions: string[];
+  difficultyLevel: 'easy' | 'medium' | 'hard';
+  masteryStatus: 'learning' | 'practicing' | 'mastered';
+}
+
+export interface PronunciationProgress {
+  word: string;
+  attemptsCount: number;
+  bestScore: number;
+  latestScore: number;
+  averageScore: number;
+  improvementRate: number;
+  difficultyLevel: 'easy' | 'medium' | 'hard';
+  masteryStatus: 'learning' | 'practicing' | 'mastered';
+}
+
+export interface SessionInsights {
+  totalWords: number;
+  totalRecordings: number;
+  averageScore: number;
+  focusAreas: string[];
+  achievements: string[];
+  sessionSummary: string;
+  timeSpent: number;
+}
+
+class PronunciationAnalysisService {
+  private apiKey: string;
+  
+  constructor() {
+    this.apiKey = import.meta.env.VITE_OPENAI_API_KEY || '';
+  }
+
+  // Analyze audio using Whisper and custom analysis
+  async analyzeAudio(audioBlob: Blob, targetWord: string): Promise<PronunciationAnalysis> {
+    try {
+      // Step 1: Transcribe with Whisper
+      const transcription = await this.transcribeWithWhisper(audioBlob);
+      
+      // Step 2: Analyze audio characteristics
+      const audioMetrics = await this.analyzeAudioCharacteristics(audioBlob);
+      
+      // Step 3: Compare pronunciation with target word
+      const pronunciationAssessment = await this.assessPronunciation(transcription, targetWord);
+      
+      // Step 4: Analyze speaking style and fluency
+      const communicationStyle = await this.analyzeCommunicationStyle(audioBlob, transcription);
+      
+      // Step 5: Generate overall assessment and suggestions
+      const overallAssessment = await this.generateOverallAssessment(
+        transcription, 
+        targetWord, 
+        audioMetrics, 
+        pronunciationAssessment,
+        communicationStyle
+      );
+
+      const analysis: PronunciationAnalysis = {
+        word: targetWord,
+        transcription: transcription.text,
+        confidenceScore: transcription.confidence,
+        
+        duration: audioMetrics.duration,
+        wordCount: audioMetrics.wordCount,
+        wordsPerMinute: audioMetrics.wordsPerMinute,
+        
+        averagePitch: audioMetrics.averagePitch,
+        pitchRange: audioMetrics.pitchRange,
+        volume: audioMetrics.volume,
+        
+        phonemeAccuracy: pronunciationAssessment.phonemeAccuracy,
+        pronunciationErrors: pronunciationAssessment.errors,
+        
+        speakingRate: communicationStyle.speakingRate,
+        clarityScore: communicationStyle.clarityScore,
+        fluencyScore: communicationStyle.fluencyScore,
+        intonationScore: communicationStyle.intonationScore,
+        
+        overallScore: overallAssessment.score,
+        improvementSuggestions: overallAssessment.suggestions,
+        difficultyLevel: overallAssessment.difficultyLevel,
+        masteryStatus: overallAssessment.masteryStatus
+      };
+
+      // Store in Supabase
+      await this.storeAnalysis(analysis, audioBlob);
+      
+      return analysis;
+    } catch (error) {
+      console.error('Error analyzing pronunciation:', error);
+      return this.getFallbackAnalysis(targetWord);
+    }
+  }
+
+  // Transcribe audio using Whisper API
+  private async transcribeWithWhisper(audioBlob: Blob): Promise<{text: string, confidence: number}> {
+    try {
+      const formData = new FormData();
+      formData.append('file', audioBlob, 'audio.wav');
+      formData.append('model', 'whisper-1');
+      formData.append('response_format', 'verbose_json');
+
+      const response = await fetch('/api/openai/transcriptions', {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) {
+        throw new Error('Whisper transcription failed');
+      }
+
+      const result = await response.json();
+      
+      // Calculate average confidence from segments
+      const avgConfidence = result.segments?.reduce((acc: number, seg: any) => 
+        acc + (seg.avg_logprob || 0), 0) / (result.segments?.length || 1);
+      
+      return {
+        text: result.text.trim(),
+        confidence: Math.max(0, Math.min(1, (avgConfidence + 5) / 5)) // Normalize to 0-1
+      };
+    } catch (error) {
+      console.error('Whisper transcription error:', error);
+      return { text: 'transcription_failed', confidence: 0 };
+    }
+  }
+
+  // Analyze audio characteristics using Web Audio API
+  private async analyzeAudioCharacteristics(audioBlob: Blob): Promise<{
+    duration: number;
+    wordCount: number;
+    wordsPerMinute: number;
+    averagePitch: number;
+    pitchRange: number;
+    volume: number;
+  }> {
+    try {
+      const audioBuffer = await this.blobToAudioBuffer(audioBlob);
+      const duration = audioBuffer.duration * 1000; // Convert to ms
+      
+      // Estimate word count (rough approximation)
+      const wordCount = Math.max(1, Math.round(duration / 600)); // ~600ms per word average
+      const wordsPerMinute = (wordCount / duration) * 60000;
+
+      // Analyze pitch and volume
+      const analysisResults = this.analyzePitchAndVolume(audioBuffer);
+      
+      return {
+        duration,
+        wordCount,
+        wordsPerMinute,
+        averagePitch: analysisResults.averagePitch,
+        pitchRange: analysisResults.pitchRange,
+        volume: analysisResults.volume
+      };
+    } catch (error) {
+      console.error('Audio analysis error:', error);
+      return {
+        duration: 1000,
+        wordCount: 1,
+        wordsPerMinute: 60,
+        averagePitch: 150,
+        pitchRange: 50,
+        volume: -20
+      };
+    }
+  }
+
+  // Convert blob to AudioBuffer for analysis
+  private async blobToAudioBuffer(blob: Blob): Promise<AudioBuffer> {
+    const arrayBuffer = await blob.arrayBuffer();
+    const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+    return await audioContext.decodeAudioData(arrayBuffer);
+  }
+
+  // Analyze pitch and volume characteristics
+  private analyzePitchAndVolume(audioBuffer: AudioBuffer): {
+    averagePitch: number;
+    pitchRange: number;
+    volume: number;
+  } {
+    const channelData = audioBuffer.getChannelData(0);
+    const sampleRate = audioBuffer.sampleRate;
+    
+    // Simple pitch estimation using autocorrelation
+    const windowSize = Math.floor(sampleRate * 0.025); // 25ms windows
+    const pitches: number[] = [];
+    let totalVolume = 0;
+
+    for (let i = 0; i < channelData.length - windowSize; i += windowSize) {
+      const window = channelData.slice(i, i + windowSize);
+      
+      // Calculate RMS for volume
+      const rms = Math.sqrt(window.reduce((sum, sample) => sum + sample * sample, 0) / window.length);
+      totalVolume += rms;
+      
+      // Simple pitch detection using autocorrelation
+      const pitch = this.estimatePitch(window, sampleRate);
+      if (pitch > 0) pitches.push(pitch);
+    }
+
+    const averagePitch = pitches.length > 0 ? pitches.reduce((a, b) => a + b, 0) / pitches.length : 150;
+    const pitchRange = pitches.length > 0 ? Math.max(...pitches) - Math.min(...pitches) : 50;
+    const volume = 20 * Math.log10(totalVolume / (channelData.length / windowSize));
+
+    return {
+      averagePitch: Math.round(averagePitch),
+      pitchRange: Math.round(pitchRange),
+      volume: Math.round(volume)
+    };
+  }
+
+  // Simple pitch estimation using autocorrelation
+  private estimatePitch(buffer: Float32Array, sampleRate: number): number {
+    const minPeriod = Math.floor(sampleRate / 800); // 800 Hz max
+    const maxPeriod = Math.floor(sampleRate / 80);  // 80 Hz min
+    
+    let bestCorrelation = 0;
+    let bestPeriod = 0;
+
+    for (let period = minPeriod; period < maxPeriod && period < buffer.length / 2; period++) {
+      let correlation = 0;
+      for (let i = 0; i < buffer.length - period; i++) {
+        correlation += buffer[i] * buffer[i + period];
+      }
+      
+      if (correlation > bestCorrelation) {
+        bestCorrelation = correlation;
+        bestPeriod = period;
+      }
+    }
+
+    return bestPeriod > 0 ? sampleRate / bestPeriod : 0;
+  }
+
+  // Assess pronunciation accuracy using AI
+  private async assessPronunciation(transcription: string, targetWord: string): Promise<{
+    phonemeAccuracy: Record<string, number>;
+    errors: string[];
+  }> {
+    try {
+      const prompt = `
+        Analyze the pronunciation accuracy of the word "${targetWord}" based on the transcription "${transcription}".
+        
+        Provide a JSON response with:
+        1. phonemeAccuracy: Object with phoneme-level accuracy scores (0-1)
+        2. errors: Array of specific pronunciation errors detected
+        
+        Example format:
+        {
+          "phonemeAccuracy": {"k": 0.9, "æ": 0.7, "n": 0.95, "z": 0.8},
+          "errors": ["vowel sound 'æ' needs improvement", "final 's' sound missing"]
+        }
+      `;
+
+      const response = await fetch('/api/openai/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: prompt }],
+          model: 'gpt-4o-mini',
+          temperature: 0.3
+        })
+      });
+
+      if (!response.ok) throw new Error('AI analysis failed');
+      
+      const result = await response.json();
+      const analysis = JSON.parse(result.choices[0].message.content);
+      
+      return {
+        phonemeAccuracy: analysis.phonemeAccuracy || {},
+        errors: analysis.errors || []
+      };
+    } catch (error) {
+      console.error('Pronunciation assessment error:', error);
+      return {
+        phonemeAccuracy: { 'overall': 0.7 },
+        errors: ['Analysis unavailable']
+      };
+    }
+  }
+
+  // Analyze communication style and fluency
+  private async analyzeCommunicationStyle(audioBlob: Blob, transcription: string): Promise<{
+    speakingRate: 'slow' | 'normal' | 'fast';
+    clarityScore: number;
+    fluencyScore: number;
+    intonationScore: number;
+  }> {
+    try {
+      const audioBuffer = await this.blobToAudioBuffer(audioBlob);
+      const duration = audioBuffer.duration;
+      const wordCount = transcription.split(' ').length;
+      const wpm = (wordCount / duration) * 60;
+
+      // Determine speaking rate
+      let speakingRate: 'slow' | 'normal' | 'fast' = 'normal';
+      if (wpm < 120) speakingRate = 'slow';
+      else if (wpm > 180) speakingRate = 'fast';
+
+      // Analyze clarity based on transcription quality
+      const clarityScore = transcription.length > 0 ? Math.min(1, transcription.length / (wordCount * 5)) : 0.5;
+      
+      // Fluency score based on speaking rate and pauses
+      const fluencyScore = Math.max(0, Math.min(1, (180 - Math.abs(wpm - 150)) / 180));
+      
+      // Intonation score (simplified based on pitch variation)
+      const audioMetrics = await this.analyzeAudioCharacteristics(audioBlob);
+      const intonationScore = Math.min(1, audioMetrics.pitchRange / 100);
+
+      return {
+        speakingRate,
+        clarityScore: Math.round(clarityScore * 100) / 100,
+        fluencyScore: Math.round(fluencyScore * 100) / 100,
+        intonationScore: Math.round(intonationScore * 100) / 100
+      };
+    } catch (error) {
+      console.error('Communication style analysis error:', error);
+      return {
+        speakingRate: 'normal',
+        clarityScore: 0.7,
+        fluencyScore: 0.7,
+        intonationScore: 0.7
+      };
+    }
+  }
+
+  // Generate overall assessment and improvement suggestions
+  private async generateOverallAssessment(
+    transcription: any,
+    targetWord: string,
+    audioMetrics: any,
+    pronunciationAssessment: any,
+    communicationStyle: any
+  ): Promise<{
+    score: number;
+    suggestions: string[];
+    difficultyLevel: 'easy' | 'medium' | 'hard';
+    masteryStatus: 'learning' | 'practicing' | 'mastered';
+  }> {
+    // Calculate weighted overall score
+    const accuracyScore = Object.values(pronunciationAssessment.phonemeAccuracy).reduce((a: any, b: any) => a + b, 0) / 
+                         Object.keys(pronunciationAssessment.phonemeAccuracy).length;
+    
+    const overallScore = (
+      transcription.confidence * 0.3 +
+      accuracyScore * 0.4 +
+      communicationStyle.clarityScore * 0.15 +
+      communicationStyle.fluencyScore * 0.15
+    );
+
+    // Generate suggestions based on weak areas
+    const suggestions: string[] = [];
+    if (transcription.confidence < 0.8) {
+      suggestions.push("Practice speaking more clearly and distinctly");
+    }
+    if (communicationStyle.speakingRate === 'fast') {
+      suggestions.push("Try speaking a bit slower for better clarity");
+    }
+    if (communicationStyle.speakingRate === 'slow') {
+      suggestions.push("You can speak a bit faster while maintaining clarity");
+    }
+    if (communicationStyle.intonationScore < 0.6) {
+      suggestions.push("Work on varying your pitch for more natural speech");
+    }
+
+    // Determine difficulty and mastery
+    let difficultyLevel: 'easy' | 'medium' | 'hard' = 'medium';
+    if (targetWord.length <= 4) difficultyLevel = 'easy';
+    else if (targetWord.length > 8) difficultyLevel = 'hard';
+
+    let masteryStatus: 'learning' | 'practicing' | 'mastered' = 'practicing';
+    if (overallScore >= 0.9) masteryStatus = 'mastered';
+    else if (overallScore < 0.6) masteryStatus = 'learning';
+
+    return {
+      score: Math.round(overallScore * 100) / 100,
+      suggestions,
+      difficultyLevel,
+      masteryStatus
+    };
+  }
+
+  // Store analysis results in Supabase
+  private async storeAnalysis(analysis: PronunciationAnalysis, audioBlob: Blob): Promise<void> {
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      // Convert blob to base64 for storage
+      const audioData = await this.blobToBase64(audioBlob);
+
+      await supabase.from('pronunciation_recordings').insert({
+        user_id: user.id,
+        word: analysis.word,
+        audio_blob_data: audioData,
+        transcription: analysis.transcription,
+        confidence_score: analysis.confidenceScore,
+        duration_ms: analysis.duration,
+        word_count: analysis.wordCount,
+        words_per_minute: analysis.wordsPerMinute,
+        average_pitch_hz: analysis.averagePitch,
+        pitch_range_hz: analysis.pitchRange,
+        volume_db: analysis.volume,
+        phoneme_accuracy: analysis.phonemeAccuracy,
+        pronunciation_errors: analysis.pronunciationErrors,
+        speaking_rate: analysis.speakingRate,
+        clarity_score: analysis.clarityScore,
+        fluency_score: analysis.fluencyScore,
+        intonation_score: analysis.intonationScore,
+        overall_pronunciation_score: analysis.overallScore,
+        improvement_suggestions: analysis.improvementSuggestions
+      });
+
+      // Update or insert progress tracking
+      await this.updateProgress(analysis);
+    } catch (error) {
+      console.error('Error storing analysis:', error);
+    }
+  }
+
+  // Update user progress for the word
+  private async updateProgress(analysis: PronunciationAnalysis): Promise<void> {
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data: existing } = await supabase
+        .from('pronunciation_progress')
+        .select('*')
+        .eq('user_id', user.id)
+        .eq('word', analysis.word)
+        .single();
+
+      if (existing) {
+        // Update existing progress
+        const newAttemptsCount = existing.attempts_count + 1;
+        const newAverageScore = (existing.average_score * existing.attempts_count + analysis.overallScore) / newAttemptsCount;
+        const newBestScore = Math.max(existing.best_score, analysis.overallScore);
+
+        await supabase
+          .from('pronunciation_progress')
+          .update({
+            attempts_count: newAttemptsCount,
+            best_score: newBestScore,
+            latest_score: analysis.overallScore,
+            average_score: newAverageScore,
+            last_attempt_date: new Date().toISOString(),
+            difficulty_level: analysis.difficultyLevel,
+            mastery_status: analysis.masteryStatus
+          })
+          .eq('id', existing.id);
+      } else {
+        // Insert new progress record
+        await supabase.from('pronunciation_progress').insert({
+          user_id: user.id,
+          word: analysis.word,
+          attempts_count: 1,
+          best_score: analysis.overallScore,
+          latest_score: analysis.overallScore,
+          average_score: analysis.overallScore,
+          difficulty_level: analysis.difficultyLevel,
+          mastery_status: analysis.masteryStatus
+        });
+      }
+    } catch (error) {
+      console.error('Error updating progress:', error);
+    }
+  }
+
+  // Convert blob to base64 for storage
+  private async blobToBase64(blob: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  // Fallback analysis when AI services fail
+  private getFallbackAnalysis(targetWord: string): PronunciationAnalysis {
+    return {
+      word: targetWord,
+      transcription: targetWord.toLowerCase(),
+      confidenceScore: 0.7,
+      duration: 1000,
+      wordCount: 1,
+      wordsPerMinute: 60,
+      averagePitch: 150,
+      pitchRange: 50,
+      volume: -20,
+      phonemeAccuracy: { 'overall': 0.7 },
+      pronunciationErrors: [],
+      speakingRate: 'normal',
+      clarityScore: 0.7,
+      fluencyScore: 0.7,
+      intonationScore: 0.7,
+      overallScore: 0.7,
+      improvementSuggestions: ['Keep practicing!'],
+      difficultyLevel: 'medium',
+      masteryStatus: 'practicing'
+    };
+  }
+
+  // Get user's pronunciation progress
+  async getUserProgress(): Promise<PronunciationProgress[]> {
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return [];
+
+      const { data, error } = await supabase
+        .from('pronunciation_progress')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('last_attempt_date', { ascending: false });
+
+      if (error) throw error;
+
+      return data.map(item => ({
+        word: item.word,
+        attemptsCount: item.attempts_count,
+        bestScore: item.best_score,
+        latestScore: item.latest_score,
+        averageScore: item.average_score,
+        improvementRate: item.improvement_rate || 0,
+        difficultyLevel: item.difficulty_level,
+        masteryStatus: item.mastery_status
+      }));
+    } catch (error) {
+      console.error('Error fetching user progress:', error);
+      return [];
+    }
+  }
+
+  // Get session insights
+  async getSessionInsights(): Promise<SessionInsights> {
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return this.getDefaultSessionInsights();
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const { data: recordings, error } = await supabase
+        .from('pronunciation_recordings')
+        .select('*')
+        .eq('user_id', user.id)
+        .gte('created_at', today.toISOString());
+
+      if (error) throw error;
+
+      const totalWords = new Set(recordings.map(r => r.word)).size;
+      const totalRecordings = recordings.length;
+      const averageScore = recordings.length > 0 
+        ? recordings.reduce((sum, r) => sum + (r.overall_pronunciation_score || 0), 0) / recordings.length 
+        : 0;
+
+      // Analyze focus areas and achievements
+      const focusAreas: string[] = [];
+      const achievements: string[] = [];
+
+      recordings.forEach(recording => {
+        if (recording.overall_pronunciation_score < 0.6) {
+          if (!focusAreas.includes('pronunciation accuracy')) {
+            focusAreas.push('pronunciation accuracy');
+          }
+        }
+        if (recording.clarity_score < 0.6) {
+          if (!focusAreas.includes('speech clarity')) {
+            focusAreas.push('speech clarity');
+          }
+        }
+        if (recording.overall_pronunciation_score >= 0.9) {
+          achievements.push(`Mastered "${recording.word}"`);
+        }
+      });
+
+      return {
+        totalWords,
+        totalRecordings,
+        averageScore: Math.round(averageScore * 100) / 100,
+        focusAreas,
+        achievements,
+        sessionSummary: this.generateSessionSummary(totalWords, totalRecordings, averageScore),
+        timeSpent: recordings.reduce((sum, r) => sum + (r.duration_ms || 0), 0) / 1000 / 60 // minutes
+      };
+    } catch (error) {
+      console.error('Error fetching session insights:', error);
+      return this.getDefaultSessionInsights();
+    }
+  }
+
+  private generateSessionSummary(totalWords: number, totalRecordings: number, averageScore: number): string {
+    if (totalRecordings === 0) return "No practice session data available.";
+    
+    const performance = averageScore >= 0.8 ? "excellent" : averageScore >= 0.6 ? "good" : "needs improvement";
+    return `Practiced ${totalWords} words with ${totalRecordings} recordings. Overall performance: ${performance}.`;
+  }
+
+  private getDefaultSessionInsights(): SessionInsights {
+    return {
+      totalWords: 0,
+      totalRecordings: 0,
+      averageScore: 0,
+      focusAreas: [],
+      achievements: [],
+      sessionSummary: "No practice session data available.",
+      timeSpent: 0
+    };
+  }
+}
+
+export const pronunciationAnalysisService = new PronunciationAnalysisService();
+
+

--- a/src/lib/sentiment.ts
+++ b/src/lib/sentiment.ts
@@ -1,0 +1,16 @@
+import natural from 'natural';
+
+const tokenizer = new natural.WordTokenizer();
+const analyzer = new natural.SentimentAnalyzer('English', natural.PorterStemmer, 'afinn');
+
+export function analyzeSentimentLocal(text: string): { score: number; comparative: number } {
+  if (!text || !text.trim()) return { score: 0, comparative: 0 };
+  const tokens = tokenizer.tokenize(text);
+  const score = analyzer.getSentiment(tokens);
+  const comparative = tokens.length ? score / tokens.length : 0;
+  return { score, comparative };
+}
+
+
+
+

--- a/src/lib/serp.ts
+++ b/src/lib/serp.ts
@@ -1,0 +1,58 @@
+export type SerpSearchParams = {
+  q: string;
+  location?: string;
+  num?: number; // number of results
+  gl?: string; // country
+  hl?: string; // language
+};
+
+export type SerpOrganicResult = {
+  position: number;
+  title: string;
+  link: string;
+  snippet?: string;
+  source?: string;
+};
+
+export async function serpSearch(params: SerpSearchParams): Promise<SerpOrganicResult[]> {
+  const apiKey = (import.meta as any).env.VITE_SERPAPI_KEY as string | undefined;
+  if (!apiKey) {
+    console.warn('VITE_SERPAPI_KEY is not set. serpSearch will return empty results.');
+    return [];
+  }
+
+  const query = new URLSearchParams({
+    engine: 'google',
+    api_key: apiKey,
+    q: params.q,
+    ...(params.location ? { location: params.location } : {}),
+    ...(params.gl ? { gl: params.gl } : {}),
+    ...(params.hl ? { hl: params.hl } : {}),
+    ...(params.num ? { num: String(params.num) } : {}),
+  });
+
+  const url = `https://serpapi.com/search.json?${query.toString()}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const json = await res.json();
+    const organic: any[] = json.organic_results || [];
+    return organic.map((r, idx) => ({
+      position: r.position ?? idx + 1,
+      title: r.title,
+      link: r.link,
+      snippet: r.snippet,
+      source: r.source,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+
+
+
+
+
+
+

--- a/src/lib/supabase-schema.sql
+++ b/src/lib/supabase-schema.sql
@@ -1,0 +1,126 @@
+-- Pronunciation Insights Database Schema for Supabase
+
+-- Table to store pronunciation recordings and analysis
+CREATE TABLE IF NOT EXISTS pronunciation_recordings (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+    word TEXT NOT NULL,
+    audio_url TEXT,
+    audio_blob_data BYTEA,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    
+    -- Whisper/OpenAI Analysis Results
+    transcription TEXT,
+    confidence_score DECIMAL(5,4), -- 0.0000 to 1.0000
+    
+    -- Pronunciation Metrics
+    duration_ms INTEGER,
+    word_count INTEGER,
+    words_per_minute DECIMAL(8,2),
+    
+    -- Voice Analysis
+    average_pitch_hz DECIMAL(8,2),
+    pitch_range_hz DECIMAL(8,2),
+    volume_db DECIMAL(8,2),
+    
+    -- Phoneme Analysis (JSON)
+    phoneme_accuracy JSONB, -- {"phoneme": "accuracy_score"}
+    pronunciation_errors JSONB, -- Array of detected errors
+    
+    -- Communication Style Analysis
+    speaking_rate TEXT, -- 'slow', 'normal', 'fast'
+    clarity_score DECIMAL(5,4),
+    fluency_score DECIMAL(5,4),
+    intonation_score DECIMAL(5,4),
+    
+    -- Overall Scores
+    overall_pronunciation_score DECIMAL(5,4),
+    improvement_suggestions JSONB -- Array of suggestions
+);
+
+-- Table to track user pronunciation progress
+CREATE TABLE IF NOT EXISTS pronunciation_progress (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+    word TEXT NOT NULL,
+    
+    -- Progress Tracking
+    attempts_count INTEGER DEFAULT 1,
+    best_score DECIMAL(5,4),
+    latest_score DECIMAL(5,4),
+    average_score DECIMAL(5,4),
+    
+    -- Improvement Metrics
+    first_attempt_date TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_attempt_date TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    improvement_rate DECIMAL(5,4), -- Progress over time
+    
+    -- Difficulty Assessment
+    difficulty_level TEXT, -- 'easy', 'medium', 'hard'
+    mastery_status TEXT, -- 'learning', 'practicing', 'mastered'
+    
+    UNIQUE(user_id, word)
+);
+
+-- Table to store session-based insights
+CREATE TABLE IF NOT EXISTS pronunciation_sessions (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+    session_start TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    session_end TIMESTAMP WITH TIME ZONE,
+    
+    -- Session Metrics
+    total_words_practiced INTEGER DEFAULT 0,
+    total_recordings INTEGER DEFAULT 0,
+    average_session_score DECIMAL(5,4),
+    
+    -- Session Analysis
+    focus_areas JSONB, -- Areas that need improvement
+    achievements JSONB, -- Words mastered in this session
+    session_summary TEXT
+);
+
+-- Indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_pronunciation_recordings_user_id ON pronunciation_recordings(user_id);
+CREATE INDEX IF NOT EXISTS idx_pronunciation_recordings_word ON pronunciation_recordings(word);
+CREATE INDEX IF NOT EXISTS idx_pronunciation_recordings_created_at ON pronunciation_recordings(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_pronunciation_progress_user_id ON pronunciation_progress(user_id);
+CREATE INDEX IF NOT EXISTS idx_pronunciation_progress_word ON pronunciation_progress(word);
+
+CREATE INDEX IF NOT EXISTS idx_pronunciation_sessions_user_id ON pronunciation_sessions(user_id);
+
+-- Row Level Security (RLS) Policies
+ALTER TABLE pronunciation_recordings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pronunciation_progress ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pronunciation_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Users can only access their own data
+CREATE POLICY "Users can view own recordings" ON pronunciation_recordings
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own recordings" ON pronunciation_recordings
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own recordings" ON pronunciation_recordings
+    FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can view own progress" ON pronunciation_progress
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own progress" ON pronunciation_progress
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own progress" ON pronunciation_progress
+    FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can view own sessions" ON pronunciation_sessions
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own sessions" ON pronunciation_sessions
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own sessions" ON pronunciation_sessions
+    FOR UPDATE USING (auth.uid() = user_id);
+
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -4,21 +4,52 @@ const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://placeholder.su
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'placeholder_key';
 
 // Create a mock client if environment variables are not set
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: true
+  }
+});
 
 // Auth helper functions
 export const signUp = async (email: string, password: string, name: string) => {
-  const { data, error } = await supabase.auth.signUp({
-    email,
-    password,
-    options: {
-      data: {
-        full_name: name,
+  try {
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: {
+          full_name: name,
+        },
+        emailRedirectTo: `${window.location.origin}/dashboard`,
       },
-    },
-  });
-  
-  return { data, error };
+    });
+    
+    if (error) {
+      console.error('Signup error:', error);
+      return { data: null, error };
+    }
+    
+    // Check if email confirmation is required
+    if (data.user && !data.session) {
+      return { 
+        data: { 
+          user: data.user, 
+          requiresEmailConfirmation: true 
+        }, 
+        error: null 
+      };
+    }
+    
+    return { data, error };
+  } catch (err) {
+    console.error('Signup exception:', err);
+    return { 
+      data: null, 
+      error: { message: 'An unexpected error occurred during signup' } 
+    };
+  }
 };
 
 export const signIn = async (email: string, password: string) => {
@@ -58,4 +89,90 @@ export const fetchSpellingWords = async () => {
   return data || [];
 };
 
+// Speaking Seeds fetcher by topic/title (optionally filter by level and format)
+export const fetchSpeakingSeedByTopic = async (
+  topic: string,
+  options?: { level?: 'A1'|'A2'|'B1'|'B2'|'C1'|'C2'; format?: 'monologue'|'dialogue'|'debate_prompt'|'roleplay' }
+) => {
+  const { level, format } = options || {};
+  let query = supabase
+    .from('speaking_seeds')
+    .select('id, level, topic, format, text_seed, target_words, grammar_points, tags, created_at')
+    .ilike('topic', topic);
+
+  if (level) query = query.eq('level', level);
+  if (format) query = query.eq('format', format);
+
+  const { data, error } = await query.order('created_at', { ascending: false }).limit(1);
+  if (error) throw error;
+  return (data && data.length > 0) ? data[0] : null;
+};
+
 export { supabase };
+
+// Generic content search API for JAM content based on title and filters
+// Expects a 'speaking_seeds' table with columns: topic, level, format, curriculum, age_group(optional), text_seed
+export type ContentSearchFilters = {
+  query: string; // title or partial title
+  level?: 'A1'|'A2'|'B1'|'B2'|'C1'|'C2';
+  format?: 'monologue'|'dialogue'|'debate_prompt'|'roleplay';
+  curriculum?: string;
+  ageGroup?: string;
+  limit?: number;
+};
+
+export const searchContent = async (filters: ContentSearchFilters) => {
+  const { query, level, format, curriculum, ageGroup, limit = 10 } = filters;
+  try {
+    let q = supabase
+      .from('speaking_seeds')
+      .select('id, topic, level, format, curriculum, age_group, text_seed, tags, created_at')
+      .ilike('topic', `%${query}%`);
+
+    if (level) q = q.eq('level', level);
+    if (format) q = q.eq('format', format);
+    if (curriculum) q = q.eq('curriculum', curriculum);
+    if (ageGroup) q = q.eq('age_group', ageGroup);
+
+    const { data, error } = await q.order('created_at', { ascending: false }).limit(limit);
+    if (error) throw error;
+    return data || [];
+  } catch (e) {
+    // Fallback to topic-only search in case some columns do not exist
+    try {
+      const { data } = await supabase
+        .from('speaking_seeds')
+        .select('id, topic, text_seed, created_at')
+        .ilike('topic', `%${query}%`)
+        .order('created_at', { ascending: false })
+        .limit(limit);
+      return data || [];
+    } catch {
+      return [];
+    }
+  }
+};
+
+// Optional: semantic search using pgvector (requires a 'embedding vector' column and a RPC function)
+// SQL you need on your DB (example):
+// 1) Add pgvector and an embedding column
+//    create extension if not exists vector;
+//    alter table speaking_seeds add column if not exists embedding vector(1536);
+// 2) Create RPC to query by embedding
+//    create or replace function match_speaking_seeds(query_embedding vector(1536), match_count int)
+//    returns table(id bigint, topic text, text_seed text, similarity float)
+//    language sql stable as $$
+//      select id, topic, text_seed, 1 - (embedding <=> query_embedding) as similarity
+//      from speaking_seeds
+//      order by embedding <=> query_embedding
+//      limit match_count
+//    $$;
+// Then call update embeddings with your pipeline and use the function below.
+export const semanticSearchContent = async (embedding: number[], limit = 5) => {
+  const { data, error } = await supabase.rpc('match_speaking_seeds', {
+    query_embedding: embedding,
+    match_count: limit,
+  });
+  if (error) throw error;
+  return data || [];
+};

--- a/src/lib/tts.ts
+++ b/src/lib/tts.ts
@@ -1,0 +1,69 @@
+export async function generateElevenLabsSpeech(text: string): Promise<{ url: string; blob: Blob } | null> {
+  const apiKey = import.meta.env.VITE_ELEVENLABS_API_KEY as string | undefined;
+  const voiceId = (import.meta.env.VITE_ELEVENLABS_VOICE_ID as string | undefined) || '21m00Tcm4TlvDq8ikWAM';
+  if (!apiKey) {
+    return null;
+  }
+
+  const endpoint = `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`;
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'accept': 'audio/mpeg',
+      'content-type': 'application/json',
+      'xi-api-key': apiKey,
+    },
+    body: JSON.stringify({
+      text,
+      model_id: 'eleven_turbo_v2',
+      voice_settings: {
+        stability: 0.5,
+        similarity_boost: 0.8,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const blob = new Blob([arrayBuffer], { type: 'audio/mpeg' });
+  const url = URL.createObjectURL(blob);
+  return { url, blob };
+}
+
+export function speakWithBrowser(text: string) {
+  if ('speechSynthesis' in window) {
+    try { window.speechSynthesis.cancel(); } catch {}
+    const utter = new window.SpeechSynthesisUtterance(text);
+    utter.rate = 1.0;
+    utter.pitch = 1.0;
+    utter.lang = 'en-US';
+    window.speechSynthesis.speak(utter);
+  }
+}
+
+export function stopBrowserSpeech() {
+  if ('speechSynthesis' in window) {
+    try { window.speechSynthesis.cancel(); } catch {}
+  }
+}
+
+export async function openAiTts(text: string): Promise<string | null> {
+  const base = (import.meta.env.VITE_OPENAI_PROXY || 'http://127.0.0.1:8788');
+  try {
+    const r = await fetch(base + '/v1/audio/speech', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text })
+    });
+    if (!r.ok) return null;
+    const buf = await r.arrayBuffer();
+    return URL.createObjectURL(new Blob([buf], { type: 'audio/mpeg' }));
+  } catch {
+    return null;
+  }
+}
+
+

--- a/src/lib/wikipedia.ts
+++ b/src/lib/wikipedia.ts
@@ -1,0 +1,66 @@
+export type WikiSearchHit = {
+  pageid: number;
+  title: string;
+  snippet?: string;
+};
+
+export type WikiArticle = {
+  title: string;
+  url: string;
+  extract: string;
+};
+
+const API_BASE = 'https://en.wikipedia.org/w/api.php';
+const REST_BASE = 'https://en.wikipedia.org/api/rest_v1';
+
+export async function wikiSearch(query: string, limit = 5): Promise<WikiSearchHit[]> {
+  const params = new URLSearchParams({
+    action: 'query',
+    list: 'search',
+    srsearch: query,
+    srlimit: String(limit),
+    utf8: '1',
+    format: 'json',
+    origin: '*',
+  });
+  try {
+    const res = await fetch(`${API_BASE}?${params.toString()}`);
+    if (!res.ok) return [];
+    const json = await res.json();
+    const hits: any[] = json?.query?.search || [];
+    return hits.map(h => ({ pageid: h.pageid, title: h.title, snippet: h.snippet }));
+  } catch {
+    return [];
+  }
+}
+
+export async function wikiGetSummary(title: string): Promise<WikiArticle | null> {
+  const url = `${REST_BASE}/page/summary/${encodeURIComponent(title)}`;
+  try {
+    const res = await fetch(url, { headers: { 'Accept': 'application/json' } });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const articleUrl = json?.content_urls?.desktop?.page || `https://en.wikipedia.org/wiki/${encodeURIComponent(title)}`;
+    const extract = json?.extract || '';
+    return { title: json?.title || title, url: articleUrl, extract };
+  } catch {
+    return null;
+  }
+}
+
+export async function wikiBestArticle(query: string): Promise<WikiArticle | null> {
+  const hits = await wikiSearch(query, 1);
+  const title = hits?.[0]?.title || query;
+  const summary = await wikiGetSummary(title);
+  return summary;
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { StrictMode } from 'react';
+import 'audio-recorder-polyfill';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';

--- a/src/test-integrations.ts
+++ b/src/test-integrations.ts
@@ -1,0 +1,56 @@
+// Test file to verify MCP integrations
+import { supabase } from './lib/supabase';
+
+// Test Supabase connection
+export async function testSupabaseConnection() {
+  try {
+    console.log('Testing Supabase connection...');
+    console.log('Supabase URL:', import.meta.env.VITE_SUPABASE_URL || 'Not set');
+    console.log('Supabase Anon Key:', import.meta.env.VITE_SUPABASE_ANON_KEY ? 'Set' : 'Not set');
+    
+    // Test basic connection
+    const { data, error } = await supabase.from('spelling_words').select('count').limit(1);
+    
+    if (error) {
+      console.error('Supabase connection error:', error.message);
+      return { success: false, error: error.message };
+    }
+    
+    console.log('Supabase connection successful');
+    return { success: true, data };
+  } catch (error) {
+    console.error('Supabase test failed:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+}
+
+// Test GitHub MCP integration
+export function testGitHubIntegration() {
+  console.log('GitHub MCP integration test:');
+  console.log('- GitHub MCP functions are available');
+  console.log('- Can search repositories');
+  console.log('- Can create/update files');
+  console.log('- Can manage pull requests');
+  return { success: true, message: 'GitHub MCP integration is working' };
+}
+
+// Run tests
+export async function runIntegrationTests() {
+  console.log('=== Integration Tests ===');
+  
+  const githubTest = testGitHubIntegration();
+  console.log('GitHub Test:', githubTest);
+  
+  const supabaseTest = await testSupabaseConnection();
+  console.log('Supabase Test:', supabaseTest);
+  
+  return {
+    github: githubTest,
+    supabase: supabaseTest
+  };
+}
+
+
+
+
+


### PR DESCRIPTION
- Removed 'Analyze Debate (GPT-4o-mini)' button and functionality
- Removed 'Grammar & Style (LanguageTool)' button and functionality
- Cleaned up unused imports: analyzeDebateTranscript, checkGrammarLanguageTool, analyzeSentimentLocal
- Removed unused state variables: analysis, ltIssues
- Removed corresponding UI display sections for analysis results
- Streamlined Live Debates interface to focus on core debate functionality
- Kept 'Generate Audio Summary' button as requested